### PR TITLE
more information when swagger error vs warning, much easier to debug #43

### DIFF
--- a/examples/2.0/index.js
+++ b/examples/2.0/index.js
@@ -36,6 +36,8 @@ if (typeof result !== 'undefined') {
 
     result.errors.forEach(function (err) {
       console.log('#/' + err.path.join('/') + ': ' + err.message);
+      //longform error
+      console.log(err);
     });
 
     console.log('');


### PR DESCRIPTION
This is my suggestion for #43 When there is an error in the swagger doc just give us the whole error object. I think that would help people just getting started with your library. Myself included. 
