### PR TITLE
gulp dist before publsihing

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Various tools for using and integrating with Swagger.",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/gulp/bin/gulp.js"
+    "test": "./node_modules/gulp/bin/gulp.js",
+    "prepublish": "./node_modules/gulp/bin/gulp.js dist"
   },
   "author": {
     "name": "Jeremy Whitlock",


### PR DESCRIPTION
Makes sure you always run `gulp dist` before publishing.
