### PR TITLE
Pass missing parameters to `send400` in QuickStart documentation

### DIFF
--- a/docs/QuickStart.md
+++ b/docs/QuickStart.md
@@ -273,12 +273,12 @@ module.exports.getWeather = function getWeather (req, res, next) {
 
   // Check that location is provided
   if (typeof location === 'undefined') {
-    return send400('location is a required query parameter');
+    return send400(res, next, 'location is a required query parameter');
   }
 
   // Code necessary to check that if unit is provided, it is one of the valid options
   if (['C', 'F'].indexOf(req.param.unit) === -1) {
-    return send400('unit must be either C or F');
+    return send400(res, next, 'unit must be either C or F');
   }
 
   // Code necessary to consume the Weather API and respond


### PR DESCRIPTION
Alternatively a `send400.bind` within the request would do but this is probably enough for a small demo.