### PR TITLE
Fix escaping of json ref for Oauth scopes.

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -554,14 +554,14 @@ var processAuthRefs = function processAuthRefs (documentMetadata, authRefs, path
 
   if (documentMetadata.swaggerVersion === '1.2') {
     _.reduce(authRefs, function (seenNames, scopes, name) {
-      var authPtr = '#/authorizations/' + name;
+      var authPtr = ['authorizations', name];
       var aPath = path.concat([name]);
 
       // Add reference or record unresolved authorization
       if (addReference(documentMetadata, authPtr, aPath, results)) {
         _.reduce(scopes, function (seenScopes, scope, index) {
           var sPath = aPath.concat(index.toString(), 'scope');
-          var sPtr = authPtr + '/scopes/' + scope.scope;
+          var sPtr = authPtr.concat(['scopes', scope.scope]);
 
           validateNoExist(seenScopes, scope.scope, code + '_SCOPE_REFERENCE', msgPrefix + ' scope reference', sPath,
                           results.warnings);
@@ -578,7 +578,7 @@ var processAuthRefs = function processAuthRefs (documentMetadata, authRefs, path
   } else {
     _.reduce(authRefs, function (seenNames, scopes, index) {
       _.each(scopes, function (scopes, name) {
-        var authPtr = '#/securityDefinitions/' + name;
+        var authPtr = ['securityDefinitions', name];
         var authRefPath = path.concat(index.toString(), name);
 
         // Ensure the security definition isn't referenced more than once (Swagger 2.0+)
@@ -591,7 +591,8 @@ var processAuthRefs = function processAuthRefs (documentMetadata, authRefs, path
         if (addReference(documentMetadata, authPtr, authRefPath, results)) {
           _.each(scopes, function (scope, index) {
             // Add reference or record unresolved authorization scope
-            addReference(documentMetadata, authPtr + '/scopes/' + scope, authRefPath.concat(index.toString()),
+            var sPtr = authPtr.concat(['scopes', scope]);
+            addReference(documentMetadata, sPtr, authRefPath.concat(index.toString()),
                          results);
           });
         }


### PR DESCRIPTION
Cause problems with scopes like: "https://www.googleapis.com/auth/drive".
Because it has slash inside and slashes should be escaped inside JSON refs.
I fix it only for Oauth scopes, but same problems exist in few more places in this file.