### PR TITLE
add 'object' type to definitions.queryParameterSubSchema.properties.type.enum

### DIFF
--- a/browser/swagger-tools-min.js
+++ b/browser/swagger-tools-min.js
@@ -1220,7 +1220,8 @@ module.exports={
             "number",
             "boolean",
             "integer",
-            "array"
+            "array",
+            "object"
           ]
         },
         "format": {

--- a/browser/swagger-tools-standalone-min.js
+++ b/browser/swagger-tools-standalone-min.js
@@ -1515,7 +1515,8 @@ module.exports={
             "number",
             "boolean",
             "integer",
-            "array"
+            "array",
+            "object"
           ]
         },
         "format": {

--- a/browser/swagger-tools-standalone.js
+++ b/browser/swagger-tools-standalone.js
@@ -23578,7 +23578,8 @@ module.exports={
             "number",
             "boolean",
             "integer",
-            "array"
+            "array",
+            "object"
           ]
         },
         "format": {

--- a/browser/swagger-tools.js
+++ b/browser/swagger-tools.js
@@ -3595,7 +3595,8 @@ module.exports={
             "number",
             "boolean",
             "integer",
-            "array"
+            "array",
+            "object"
           ]
         },
         "format": {


### PR DESCRIPTION
the reason for this is to expose the mongodb readonly query api (see working screenshot, with hack applied to swagger-ui client)
![screen shot 2015-03-26 at 12 54 13](https://cloud.githubusercontent.com/assets/280571/6840629/5d14ef5a-d3b7-11e4-9cea-95b9e9acb633.png)
