### PR TITLE
Better regex for importing controllers

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -56,7 +56,7 @@ var getHandlerName = function getHandlerName (req) {
 };
 var handlerCacheFromDir = function handlerCacheFromDir (dirOrDirs) {
   var handlerCache = {};
-  var jsFileRegex = /\.js|\.coffee$/;
+  var jsFileRegex = /\.js$|\.coffee$/;
   var dirs = [];
 
   if (_.isArray(dirOrDirs)) {


### PR DESCRIPTION
Adding a '$' to the regex matching js files that need to be required.
This way files that contain the string '.js' but don't end with it
(like temporary vim files for example - file.js.swp) do not get
required.