### PR TITLE
More precise number/integer validation

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -432,10 +432,10 @@ var validateTypeAndFormat = module.exports.validateTypeAndFormat =
         result = _.isBoolean(val) || ['false', 'true'].indexOf(val) !== -1;
         break;
       case 'integer':
-        result = !_.isNaN(parseInt(val, 10));
+        result = _.isFinite(Number(val)) && !_.isNaN(parseInt(val, 10));
         break;
       case 'number':
-        result = !_.isNaN(parseFloat(val));
+        result = _.isFinite(Number(val)) && !_.isNaN(parseFloat(val));
         break;
       case 'string':
         if (!_.isUndefined(format)) {


### PR DESCRIPTION
Hi, I detect the follow problem with the validator rules of both *integer* and *number*.

If a value starts with number, it returns true, even if there's letters in it.

Example:
```js
!_.isNaN(parseInt(value, 10)); //true
!_.isNaN(parseInt("0arg", 10)); //true
!_.isNaN(parseInt("arg0", 10)); //false (like in the unit tests)
```

This little PR fixes this unexpected behavior.

