### PR TITLE
Make the router work with controllers named only by operationId

### DIFF
--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -396,6 +396,10 @@ where each operation tells you which controller and function will be used based 
 }
 ```
 
+If `x-swagger-router-controller` is omitted and only `operationId` is given, the router will try to match directly
+to a method  using the `operationId` as method name.
+This works only if the controller is passed to the router directly as an object.
+
 A new option (since 0.8.4) is the addition of the `x-swagger-router-handle-subpaths` extension to the Swagger path
 component. By setting this property to `true`, it indicates to Swagger Router that it should match and route all 
 requests to not only the specified path, but also any undeclared subpaths requested that do not match an explicitly 

--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -44,10 +44,14 @@ var getHandlerName = function getHandlerName (req) {
     break;
 
   case '2.0':
-    handlerName = (req.swagger.operation['x-swagger-router-controller'] ?
-      req.swagger.operation['x-swagger-router-controller'] :
-      req.swagger.path['x-swagger-router-controller']) + '_' +
-      (req.swagger.operation.operationId ? req.swagger.operation.operationId : req.method.toLowerCase());
+    if (req.swagger.operation['x-swagger-router-controller'] || req.swagger.path['x-swagger-router-controller']) {
+      handlerName = (req.swagger.operation['x-swagger-router-controller'] ?
+        req.swagger.operation['x-swagger-router-controller'] :
+        req.swagger.path['x-swagger-router-controller']) + '_' +
+        (req.swagger.operation.operationId ? req.swagger.operation.operationId : req.method.toLowerCase());
+    } else {
+      handlerName = req.swagger.operation.operationId;
+    }
 
     break;
   }

--- a/test/2.0/test-middleware-swagger-router.js
+++ b/test/2.0/test-middleware-swagger-router.js
@@ -137,6 +137,28 @@ describe('Swagger Router Middleware v2.0', function () {
     });
   });
 
+  it('should do routing when only operationId is given', function (done) {
+    var cPetStoreJson = _.cloneDeep(petStoreJson);
+    var controller = require('../controllers/Users');
+
+    // Use Users controller
+    delete cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'];
+    cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getById';
+
+    helpers.createServer([cPetStoreJson], {
+      swaggerRouterOptions: {
+        controllers: {
+          'getById': controller.getById
+        }
+      }
+    }, function (app) {
+      request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(controller.response, done));
+    });
+  });
+
   it('should not do any routing when there is no controller and use of stubs is off', function (done) {
     helpers.createServer([petStoreJson], {
       handler: function (req, res) {


### PR DESCRIPTION
If x-swagger-router-controller is not set the router will try to match
the handler only by operationId. This makes it easier to use swagger-tools
without having to add the non standard field x-swagger-router-controller
to the swagger specification file.