### PR TITLE
Add the expected media type to the request headers

### DIFF
--- a/bin/swagger-tools
+++ b/bin/swagger-tools
@@ -64,6 +64,7 @@ var getDocument = function getDocument (pathOrUrl, callback) {
   } else if (/^https?:\/\//.test(pathOrUrl)) {
     request.get(pathOrUrl)
       .set('user-agent', 'apigee-127/swagger-tools')
+      .set('accept', 'application/json, text/x-yaml')
       .end(function (err, res) {
         if (err) {
           callback(err);


### PR DESCRIPTION
parseContent() expects only json or yaml.
Help API's providing multiple media types to choose the expected format.