### PR TITLE
Skip validation of unspecified response codes.

### DIFF
--- a/test/2.0/test-middleware-swagger-validator.js
+++ b/test/2.0/test-middleware-swagger-validator.js
@@ -443,9 +443,11 @@ describe('Swagger Validator Middleware v2.0', function () {
       cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
       helpers.createServer([cPetStoreJson], {
-        conrollers: {
-          'Pets_getPetById': function (req, res) {
-            res.end('OK');
+        swaggerRouterOptions: {
+          controllers: {
+            'Pets_getPetById': function (req, res) {
+              res.end('OK');
+            }
           }
         },
         swaggerValidatorOptions: {

--- a/test/2.0/test-middleware-swagger-validator.js
+++ b/test/2.0/test-middleware-swagger-validator.js
@@ -459,6 +459,33 @@ describe('Swagger Validator Middleware v2.0', function () {
       });
     });
 
+    it('should not validate response when status code unspecified and there is no default', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      delete cPetStoreJson.paths['/pets/{id}'].get.responses.default;
+
+      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+          controllers: {
+            'Pets_getPetById': function (req, res) {
+              res.statusCode = 304;
+              res.end();
+            }
+          }
+        },
+        swaggerValidatorOptions: {
+          validateResponse: true
+        }
+      }, function (app) {
+        request(app)
+          .get('/api/pets/1')
+          .expect(304)
+          .end(done);
+      });
+    });
+
     it('should return an error for invalid response content type', function (done) {
       var cPetStoreJson = _.cloneDeep(petStoreJson);
 


### PR DESCRIPTION
I might be wrong on this, but if I read the swagger specification right, there is no need to specify every possible response nor to define a default. In my particular case status code 304 was not given in the swagger document but the validator was still trying to operate on an undefined response schema (object).