### PR TITLE
added results object to output response when validation failed

### DIFF
--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -223,7 +223,8 @@ var wrapEnd = function wrapEnd (req, res, next) {
     } catch (err) {
       if (err.failedValidation) {
         err.originalResponse = data;
-        err.message = 'Response validation failed: ' + err.message.charAt(0).toLowerCase() + err.message.substring(1);
+        err.message = 'Response validation failed: ' + err.message.charAt(0).toLowerCase() + err.message.substring(1)
+            + '\nResults of validation: ' + JSON.stringify(err.results, null, 2);
       }
 
       return next(err);


### PR DESCRIPTION
Without this change, the results of the validation are obscured in the output to the web client.

With the change you get something like this:

Error: Response validation failed: failed schema validation
Results of validation: {
 "errors": [
   {
     "code": "OBJECT_MISSING_REQUIRED_PROPERTY",
     "message": "Missing required property: ip",
     "path": [
       "0"
     ]
   }
 ],
 "warnings": []
}
   at throwErrorWithCode (/home/ndunn/Dropbox/swagger-tools/lib/validators.js:97:13)
   at Object.validateAgainstSchema (/home/ndunn/Dropbox/swagger-tools/lib/validators.js:126:7)
   at /home/ndunn/Dropbox/swagger-tools/middleware/swagger-validator.js:119:22
   at /home/ndunn/Dropbox/swagger-tools/node_modules/async/lib/async.js:246:17
   at /home/ndunn/Dropbox/swagger-tools/node_modules/async/lib/async.js:122:13
   at _each (/home/ndunn/Dropbox/swagger-tools/node_modules/async/lib/async.js:46:13)
   at async.each (/home/ndunn/Dropbox/swagger-tools/node_modules/async/lib/async.js:121:9)
   at _asyncMap (/home/ndunn/Dropbox/swagger-tools/node_modules/async/lib/async.js:245:13)
   at Object.map (/home/ndunn/Dropbox/swagger-tools/node_modules/async/lib/async.js:216:23)
   at validateValue (/home/ndunn/Dropbox/swagger-tools/middleware/swagger-validator.js:112:11)
   at ServerResponse.end (/home/ndunn/Dropbox/swagger-tools/middleware/swagger-validator.js:210:7)
   at workers (/storage/onesafSimulationCenter/server/app/api/controllers/worker.js:57:9)
   at swaggerRouter (/home/ndunn/Dropbox/swagger-tools/middleware/swagger-router.js:392:20)
   at Layer.handle [as handle_request] (/storage/onesafSimulationCenter/server/node_modules/express/lib/router/layer.js:82:5)
   at trim_prefix (/storage/onesafSimulationCenter/server/node_modules/express/lib/router/index.js:302:13)
   at /storage/onesafSimulationCenter/server/node_modules/express/lib/router/index.js:270:7 