### PR TITLE
Fix array params with non-string items

### DIFF
--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -119,7 +119,7 @@ var convertValue = function convertValue (value, schema, type) {
     }
 
     value = _.map(value, function (item) {
-      return convertValue(item, _.isArray(schema.items) ? schema.items[0] : schema.items);
+      return convertValue(item, _.isArray(schema.items) ? schema.items[0] : schema.items.type);
     });
 
     break;

--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -285,7 +285,7 @@ exports = module.exports = function swaggerValidatorMiddleware (options) {
                     paramPath = swaggerVersion === '1.2' ?
                       req.swagger.operationPath.concat(['params', paramIndex.toString()]) :
                       parameter.path;
-                    val = req.swagger.params[paramName].originalValue;
+                    val = req.swagger.params[paramName].value;
 
                     // Validate requiredness
                     validators.validateRequiredness(val, schema.required);


### PR DESCRIPTION
When using a schema where the items of an array have type integers:
* the value conversion failed to use the correct item type
* the validator validated the originalValue (before splitting) instead of each of the items individually