### PR TITLE
Let collectionFormat default to csv if undefined

### DIFF
--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -103,9 +103,10 @@ var convertValue = function convertValue (value, schema, type) {
 
   switch (type) {
   case 'array':
-    if (_.isString(value) && !_.isUndefined(schema.collectionFormat) && schema.collectionFormat !== 'multi') {
+    if (_.isString(value) && schema.collectionFormat !== 'multi') {
       switch (schema.collectionFormat) {
       case 'csv':
+      case undefined:
         value = value.split(',');
         break;
       case 'pipes':

--- a/test/2.0/test-middleware-swagger-metadata.js
+++ b/test/2.0/test-middleware-swagger-metadata.js
@@ -519,20 +519,25 @@ describe('Swagger Metadata Middleware v2.0', function () {
     it('should handle collectionFormat (Issue #167)', function (done) {
       var values = ['me', 'you', 'us'];
 
-      async.map(['csv', 'multi', 'pipes', 'ssv', 'tsv'], function (format, callback) {
+      async.map(['csv', 'multi', 'pipes', 'ssv', 'tsv', undefined], function (format, callback) {
         var swaggerObject = _.cloneDeep(petStoreJson);
 
-        swaggerObject.paths['/pets'].get.parameters.push({
-            in: 'query',
+        var param = {
+          in: 'query',
           name: 'myArr',
           description: 'Simple array value',
           required: true,
           type: 'array',
           items: {
             type: 'string'
-          },
-          collectionFormat: format
-        });
+          }
+        };
+
+        if(format) {
+          param.collectionFormat = format;
+        }
+
+        swaggerObject.paths['/pets'].get.parameters.push(param);
 
         helpers.createServer([swaggerObject], {
           swaggerRouterOptions: {
@@ -553,7 +558,9 @@ describe('Swagger Metadata Middleware v2.0', function () {
           case 'pipes':
           case 'ssv':
           case 'tsv':
+          case undefined:
             switch (format) {
+            case undefined:
             case 'csv':
               d = ',';
 


### PR DESCRIPTION
The swagger [spec](http://swagger.io/specification/#parameterType) says csv is the default for collectionFormat (unless I am reading it totally wrong?).