### PR TITLE
A bigger limit for request - 1000kb

### DIFF
--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -42,7 +42,7 @@ var multerOptions = {
   inMemory: true
 };
 
-var jsonBodyParser = bp.json();
+var jsonBodyParser = bp.json({limit: '1000kb'});
 var parseQueryString = mHelpers.parseQueryString;
 var queryParser = function (req, res, next) {
   if (_.isUndefined(req.query)) {


### PR DESCRIPTION
Currently, body-parser package has an internal limit for a request of 100kb. 
We had much larger requests sent through our swagger API, which caused our requests to fail with error 413. 
We increased the default limit to a larger one - 1000kb. 
I believe this can be integrated into the swagger interface and propogated back down to body-parser, which will be a better way to handle this case, but as a default is already set in body-parser, best to set a bigger limit on the request. 
