### PR TITLE
Report errors for decimal integers in swagger-validator.

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -469,15 +469,15 @@ var validateTypeAndFormat = module.exports.validateTypeAndFormat =
       case 'integer':
         // Coerce the value only for Swagger 1.2
         if (version === '1.2' && _.isString(val)) {
-          val = parseInt(val, 10);
+          val = Number(val);
         }
 
-        result = _.isFinite(val);
+        result = _.isFinite(val) && (Math.round(val) === val);
         break;
       case 'number':
         // Coerce the value only for Swagger 1.2
         if (version === '1.2' && _.isString(val)) {
-          val = parseFloat(val);
+          val = Number(val);
         }
 
         result = _.isFinite(val);

--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -146,7 +146,7 @@ var convertValue = function (value, schema, type) {
 
   case 'integer':
     if (!_.isNumber(value)) {
-      value = parseInt(value, 10);
+      value = Number(value);
 
       if (isNaN(value)) {
         value = original;
@@ -157,7 +157,7 @@ var convertValue = function (value, schema, type) {
 
   case 'number':
     if (!_.isNumber(value)) {
-      value = parseFloat(value);
+      value = Number(value);
 
       if (isNaN(value)) {
         value = original;

--- a/test/2.0/test-middleware-swagger-validator.js
+++ b/test/2.0/test-middleware-swagger-validator.js
@@ -1188,5 +1188,68 @@ describe('Swagger Validator Middleware v2.0', function () {
           .end(done);
       });
     });
+
+    it('should return an error for decimal "integers" (Issue 279)', function (done) {
+      var cPetStore = _.cloneDeep(petStoreJson);
+      var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: 1.1';
+
+      cPetStore.paths['/pets/{id}'].get.parameters = [{
+        in: 'query',
+        name: 'arg0',
+        type: 'integer'
+      }];
+
+      helpers.createServer([cPetStore], {}, function (app) {
+        request(app)
+          .get('/api/pets/1')
+          .query({
+            arg0: 1.1
+          })
+          .expect(400)
+          .end(helpers.expectContent(expectedMessage, done));
+      });
+    });
+
+    it('should return an error for number+string "numbers" (Issue 279)', function (done) {
+      var cPetStore = _.cloneDeep(petStoreJson);
+      var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid number: 2something';
+
+      cPetStore.paths['/pets/{id}'].get.parameters = [{
+        in: 'query',
+        name: 'arg0',
+        type: 'number'
+      }];
+
+      helpers.createServer([cPetStore], {}, function (app) {
+        request(app)
+          .get('/api/pets/1')
+          .query({
+            arg0: '2something'
+          })
+          .expect(400)
+          .end(helpers.expectContent(expectedMessage, done));
+      });
+    });
+
+    it('should return an error for number+string "integers" (Issue 279)', function (done) {
+      var cPetStore = _.cloneDeep(petStoreJson);
+      var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: 2something';
+
+      cPetStore.paths['/pets/{id}'].get.parameters = [{
+        in: 'query',
+        name: 'arg0',
+        type: 'integer'
+      }];
+
+      helpers.createServer([cPetStore], {}, function (app) {
+        request(app)
+          .get('/api/pets/1')
+          .query({
+            arg0: '2something'
+          })
+          .expect(400)
+          .end(helpers.expectContent(expectedMessage, done));
+      });
+    });
   });
 });

--- a/test/2.0/test-specs.js
+++ b/test/2.0/test-specs.js
@@ -2688,5 +2688,83 @@ describe('Specification v2.0', function () {
         done();
       });
     });
+
+    it('should reject decimal "integers" as defaults (Issue 279)', function (done) {
+      var swaggerObject = _.cloneDeep(petStoreJson);
+
+      swaggerObject.definitions.Pet.properties.fake = {
+        type: 'integer',
+        default: 1.1
+      };
+
+      spec.validate(swaggerObject, function (err, result) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.deepEqual(result.errors, [
+          {
+            code: 'INVALID_TYPE',
+            message: 'Not a valid integer: 1.1',
+            path: ['definitions', 'Pet', 'properties', 'fake', 'default']
+          }
+        ]);
+        assert.equal(result.warnings.length, 0);
+
+        done();
+      });
+    });
+
+    it('should reject number+string "numbers" as defaults (Issue 279)', function (done) {
+      var swaggerObject = _.cloneDeep(petStoreJson);
+
+      swaggerObject.definitions.Pet.properties.fake = {
+        type: 'number',
+        default: '2something'
+      };
+
+      spec.validate(swaggerObject, function (err, result) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.deepEqual(result.errors, [
+          {
+            code: 'INVALID_TYPE',
+            message: 'Not a valid number: 2something',
+            path: ['definitions', 'Pet', 'properties', 'fake', 'default']
+          }
+        ]);
+        assert.equal(result.warnings.length, 0);
+
+        done();
+      });
+    });
+
+    it('should reject number+string "integers" as defaults (Issue 279)', function (done) {
+      var swaggerObject = _.cloneDeep(petStoreJson);
+
+      swaggerObject.definitions.Pet.properties.fake = {
+        type: 'integer',
+        default: '2something'
+      };
+
+      spec.validate(swaggerObject, function (err, result) {
+        if (err) {
+          return done(err);
+        }
+
+        assert.deepEqual(result.errors, [
+          {
+            code: 'INVALID_TYPE',
+            message: 'Not a valid integer: 2something',
+            path: ['definitions', 'Pet', 'properties', 'fake', 'default']
+          }
+        ]);
+        assert.equal(result.warnings.length, 0);
+
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
Sorry for the unsolicited PR; I had the fix as a part of investigating the problem, and figured I'd cut to to chase.

The issue is that `swagger-validator` doesn't report errors for decimal numbers when the parameter is an "integer". The root cause, however, lies in `swagger-metadata`, which truncates Strings down to integer Numbers for "integer"-formatted parameters. _Included is the most concise fix I could think of, though there are others available._ 

I'm invested in seeing the feature through, and would like to block merging on two tasks, both requiring discussion:
- [x] Regression testing
- [x] Design iteration

## Regression Testing

_Where would you like the tests?_ I can add an additional assertion to `test/2.0/test-middleware-swagger-validator.js:203`, but that would require refactoring the test to allow each scenario to specify the input value, much like `:308`. It looks like regression tests don't have a dedicated area of the spec, but I'm happy to create one.

## Design iteration

_Why `parseFloat` in lieu of `Number?`_ With the former, `'2arg'` will be treated as a valid parameter with the value `2`. With the latter, `'2arg'` will be rejected as `NaN`. This seems like a better design to me, but I want your input. If it's amenable to you, I can move the appropriate code over to using `Number` instead of the `parse*` variants.

_Linting issues._ My original fix for `swagger-validator.js:475` included an expression rejected by the linter: `(~~val == val)`. Is this expression clear enough to add an inline exception for jshint? Would you prefer to see `parseFloat`, as it stands now?