### PR TITLE
Get mock values from `schema.example` (if no `default` value)

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -123,6 +123,8 @@ var getMockValue = function (version, schema) {
       value = schema.defaultValue;
     } else if (version === '2.0' && !_.isUndefined(schema.default)) {
       value = schema.default;
+    } else if (version === '2.0' && !_.isUndefined(schema.example)) {
+        value = schema.example;
     } else if (_.isArray(schema.enum)) {
       value = schema.enum[0];
     } else {
@@ -145,6 +147,8 @@ var getMockValue = function (version, schema) {
       value = schema.defaultValue;
     } else if (version === '2.0' && !_.isUndefined(schema.default)) {
       value = schema.default;
+    } else if (version === '2.0' && !_.isUndefined(schema.example)) {
+        value = schema.example;
     } else if (_.isArray(schema.enum)) {
       value = schema.enum[0];
     } else {
@@ -180,6 +184,8 @@ var getMockValue = function (version, schema) {
       value = schema.defaultValue;
     } else if (version === '2.0' && !_.isUndefined(schema.default)) {
       value = schema.default;
+    } else if (version === '2.0' && !_.isUndefined(schema.example)) {
+        value = schema.example;
     } else if (_.isArray(schema.enum)) {
       value = schema.enum[0];
     } else {
@@ -200,6 +206,8 @@ var getMockValue = function (version, schema) {
       value = schema.defaultValue;
     } else if (version === '2.0' && !_.isUndefined(schema.default)) {
       value = schema.default;
+    } else if (version === '2.0' && !_.isUndefined(schema.example)) {
+        value = schema.example;
     } else if (_.isArray(schema.enum)) {
       value = schema.enum[0];
     } else {

--- a/test/2.0/test-middleware-swagger-router.js
+++ b/test/2.0/test-middleware-swagger-router.js
@@ -293,6 +293,174 @@ describe('Swagger Router Middleware v2.0', function () {
       done();
     });
   });
+    
+  describe('get mock values from default then example', function () {
+    it('should return mock string from default over example', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'string',
+          pattern: '^([A-Za-z0-9]*)$',
+          example: 'exampleString',
+          default: 'defaultString'
+      };
+          
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify('defaultString'), done));
+      });
+    });
+
+    it('should return mock string from example if no default', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+          
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'string',
+          pattern: '^([A-Za-z0-9]*)$',
+          example: 'exampleString'
+      };
+
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify('exampleString'), done));
+      });
+    });
+
+    it('should return mock number from default over example', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'number',
+          example: 1.01,
+          default: 2.02
+      };
+          
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify(2.02), done));
+      });
+    });
+
+    it('should return mock number from example if no default', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+          
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'number',
+          example: 1.01
+      };
+
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify(1.01), done));
+      });
+    });
+  
+    it('should return mock integer from default over example', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'integer',
+          example: 1,
+          default: 2
+      };
+          
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify(2), done));
+      });
+    });
+
+    it('should return mock integer from example if no default', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+          
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'integer',
+          example: 1
+      };
+
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify(1), done));
+      });
+    });
+  
+    it('should return mock boolean from default over example', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'boolean',
+          example: false,
+          default: true
+      };
+          
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify(true), done));
+      });
+    });
+
+    it('should return mock boolean from example if no default', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+          
+      cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema = {
+          type: 'boolean',
+          example: true
+      };
+
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+            useStubs: true
+        }
+      }, function (app) {
+        request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(JSON.stringify(true), done));
+      });
+    });
+  });
 
   describe('issues', function () {
     it('should handle uncaught exceptions (Issue 123)', function (done) {


### PR DESCRIPTION
You may not want to define a `default` value for a schema object, but still want to provide representative examples, particularly in mock responses.

This is particularly important where `string` type uses a `pattern` that doesn't match the hard-coded mock values, which in turns causes the mocked response to fail the response validator. This change allows mock values to be pulled from the `example` field to solve this problem.

`example` is inserted between `default` and `enum`, leaving the the mock value source precedence as:
1. `1.2` `defaultValue`
2. `2.0` `default`
3. `2.0` `example`
4. `enum` (first value)
5. hardcoded value (or *now* for date/date-time)

### Test plan:
* Added unit tests to cover the appropriate selection of `default` and `example` as the mock value for string, number, integer, and boolean types.
* Used gulp to run lint and all unit tests and ensured everything passes.
* Used coverage report to verify all new lines were tested at least once.

### Example use case:
Schema is
```lang=js
...
"definitions": {
  "alpha": {
      "description": "Text with only ascii letters",
      "type": "string",
      "pattern": "^([A-Za-z]*)$",
      "example": "SomeTextWithOnlyAsciiLetters"
    },
}
...
```
Before this change, the mock response would be `"Sample Text"` which would then fail the response validator as it has a space (which isn't allowed according to the `pattern`).
After the change, the mock response would be `"SomeTextWithOnlyAsciiLetters"`, which is a valid response.

### Caveats
* This change doesn't fix all such issues.  In particular it doesn't use `example` fields higher up the chain (e.g. `object` types, or whole `responses`). This would require more extensive rework of how mock values are created.
* This change doesn't attempt to validate the `example` value. This was suggested as a requirement in #30 by @whitlockjc. My assumption in this change is that examples are valid values or can be made so.  

### Alternative options
If this is not a good use of the `example` field, an alternative, and equally simple, option might be to us a custom `x-mock-value` parameter (or similar) to get the value from.