### PR TITLE
Nested folders for controllers

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -58,6 +58,24 @@ var getHandlerName = function (req) {
 
   return handlerName;
 };
+var getAllFiles = function(dir, filelist) {
+  var files = fs.readdirSync(dir);
+  filelist = filelist || [];
+
+  _.each(files, function(file) {
+    var filePath = path.resolve(dir, file);
+
+    if (fs.statSync(filePath).isDirectory()) {
+      filelist = getAllFiles(filePath, filelist);
+    }
+    else {
+      filelist.push(filePath);
+    }
+    
+  });
+
+  return filelist;
+};
 var handlerCacheFromDir = function (dirOrDirs) {
   var handlerCache = {};
   var jsFileRegex = /\.(coffee|js)$/;
@@ -77,14 +95,14 @@ var handlerCacheFromDir = function (dirOrDirs) {
     _.each(getAllFiles(dir), function (file) { // iterate for each file
       //Checks to see if it is a js file
       debug('    %s%s:', file, (file.match(jsFileRegex) ? '' : ' (not a js file, skipped)'));
-      if ( !file.match(jsFileRegex) ) return; // Needs to be a js file
+      if ( !file.match(jsFileRegex) ) { return; }
 
       var controllerName = file.replace(parentDir+'/', '').replace(jsFileRegex, '');
       var controller     = require(file); 
 
       // Checks to see if it is a plain object
       debug('    %s%s:', file, (_.isPlainObject(controller) ? '' : ' (not an object, skipped)'));
-      if ( !_.isPlainObject(controller) ) return; 
+      if ( !_.isPlainObject(controller) ) { return; }
 
 
       _.each(controller, function(value, functionName) {
@@ -103,24 +121,6 @@ var handlerCacheFromDir = function (dirOrDirs) {
   });
 
   return handlerCache;
-};
-var getAllFiles = function(dir, filelist) {
-  var files = fs.readdirSync(dir);
-  filelist = filelist || [];
-
-  _.each(files, function(file) {
-    var filePath = path.resolve(dir, file);
-
-    if (fs.statSync(filePath).isDirectory()) {
-      filelist = getAllFiles(filePath, filelist);
-    }
-    else {
-      filelist.push(filePath);
-    }
-    
-  });
-
-  return filelist;
 };
 var getMockValue = function (version, schema) {
   var type = _.isPlainObject(schema) ? schema.type : schema;


### PR DESCRIPTION
If you try to use a structure like this for your controllers, the file `hell.js` will be ignored.

<img width="120" alt="screen shot 2016-01-06 at 3 13 15 am" src="https://cloud.githubusercontent.com/assets/274971/12135489/9dc9d39c-b423-11e5-85dd-f1e10a0e3133.png">

The issue is that the `handlerCache` is going only one level deep, and looking for everything that is a file. It looks at `hell`, which is a folder, and ignores it.

I've changed the approach, which now looks at the folder(s) supplied and create an array with all the files in the root and the nested folders. Then it uses this array to see which ones are js and plain objects with valid unique functions (phew!), and add everything to `handlerCache`.

I've kept the naming structure for `handlerId`, which means that every other function already knows how to look for the controller/function they're trying to find. With that I get less chances of introducing bugs :smile: 

Since I couldn't figure out how to properly test it, I tested it on the sample project I had created with a few variations of folder structure, which all worked fine. If there's a way to test it properly, let me know so I can do that before the merge.

Cheers! :octocat: 

Fixes #283 