### PR TITLE
fixing swagger-ui api url

### DIFF
--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -499,10 +499,12 @@ The Swagger UI middleware is used to serve your Swagger document(s) via an API a
 
 * **options:** `object` The middleware options
 * **options.apiDocs:** `string=/api-docs` The path to serve the Swagger documents from
-* **options.apiDocsPrefix:** `string=` The prefix to append to the `options.apiDocs` _(This is required when serving a
+* **options.apiDocsPrefix:** `string=` The prefix to prepend to the `options.apiDocs` _(This is required when serving a
 swagger-tools based API behind a reverse proxy.)_
 * **options.swaggerUi:** `string=/docs` The path to serve Swagger UI from
 * **options.swaggerUiDir:** `string` The filesystem path to your custom swagger-ui deployment to serve
+* **options.swaggerUiPrefix:** `string` The prefix to prepend to the `options.swaggerUi` _(This is required when serving a
+swagger-tools UI behind a reverse proxy.)_
 
 **Returns**
 

--- a/middleware/swagger-ui.js
+++ b/middleware/swagger-ui.js
@@ -135,7 +135,7 @@ exports = module.exports = function (rlOrSO, apiDeclarations, options) {
       swaggerApiDocsURL = parseurl.original(req).pathname;
 
       // Remove the part after the mount point
-      swaggerApiDocsURL = swaggerApiDocsURL.substring(0, swaggerApiDocsURL.indexOf(req.url));
+      swaggerApiDocsURL = swaggerApiDocsURL.substring(0, swaggerApiDocsURL.indexOf(options.swaggerUi));
 
       // Add the API docs path and remove any double dashes
       swaggerApiDocsURL = (swaggerApiDocsURL + options.apiDocs).replace(/\/\//g, '/');

--- a/middleware/swagger-ui.js
+++ b/middleware/swagger-ui.js
@@ -135,10 +135,10 @@ exports = module.exports = function (rlOrSO, apiDeclarations, options) {
       swaggerApiDocsURL = parseurl.original(req).pathname;
 
       // Remove the part after the mount point
-      swaggerApiDocsURL = swaggerApiDocsURL.substring(0, swaggerApiDocsURL.indexOf(options.swaggerUi));
-
+      swaggerApiDocsURL = swaggerApiDocsURL.substring(0, swaggerApiDocsURL.indexOf(req.url));
+      
       // Add the API docs path and remove any double dashes
-      swaggerApiDocsURL = (swaggerApiDocsURL + options.apiDocs).replace(/\/\//g, '/');
+      swaggerApiDocsURL = ((options.swaggerUiPrefix ? options.swaggerUiPrefix : '') + swaggerApiDocsURL + options.apiDocs).replace(/\/\//g, '/'); 
     }
 
     debug('%s %s', req.method, req.url);

--- a/test/2.0/test-middleware-swagger-ui.js
+++ b/test/2.0/test-middleware-swagger-ui.js
@@ -146,6 +146,22 @@ describe('Swagger UI Middleware v2.0', function () {
       });
     });
 
+    it('should serve Swagger UI with Swagger UI Prefix setting (issue #297)', function (done) {
+      helpers.createServer([swaggerObject], {
+        swaggerUiOptions: {
+          swaggerUi: '/docs2',
+          swaggerUiPrefix: '/something'
+        }
+      }, function (app) {
+        request(app)
+          .get('/docs2/') // Trailing slash to avoid a 303
+          .expect(200)
+          .expect('content-type', 'text/html; charset=UTF-8')
+          .expect('swagger-api-docs-url', '/something/api-docs')
+          .end(done);
+      });
+    });
+
     it('should serve Swagger document at explicit path (Issue 183)', function (done) {
       helpers.createServer([swaggerObject], {
         swaggerUiOptions: {


### PR DESCRIPTION
a fix for: swagger-ui middleware generates wrong URL when behind a proxy #297