### PR TITLE
Allow middleware parsers options override

### DIFF
--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -163,7 +163,15 @@ body and query string parsing respectively if you do not provide your own parser
 
 ### Swagger 1.2
 
-#### #swaggerMetadata()
+#### #swaggerMetadata(options)
+
+**Arguments**
+
+* **options:** `[object]` The configuration options
+* **options.multerOptions:** `[object]` The options passed to `multer`, for example `{ dest: 'uploads/' }`
+* **options.bodyParserOptions:** `[object]` The options passed to `bodyParser#urlencoded`
+* **options.jsonBodyParserOptions:** `[object]` The options passed to `bodyParser#json`
+* **options.textBodyParserOptions:** `[object]` The options passed to `bodyParser#text`
 
 **Returns**
 

--- a/index.js
+++ b/index.js
@@ -90,10 +90,10 @@ var initializeMiddleware = function initializeMiddleware (rlOrSO, resources, cal
 
     callback({
       // Create a wrapper to avoid having to pass the non-optional arguments back to the swaggerMetadata middleware
-      swaggerMetadata: function () {
+      swaggerMetadata: function (options) {
         var swaggerMetadata = require('./middleware/swagger-metadata');
 
-        return swaggerMetadata.apply(undefined, args.slice(0, args.length - 1));
+        return swaggerMetadata.apply(undefined, args.slice(0, args.length - 1).concat(options));
       },
       swaggerRouter: require('./middleware/swagger-router'),
       swaggerSecurity: require('./middleware/swagger-security'),

--- a/middleware/helpers.js
+++ b/middleware/helpers.js
@@ -116,8 +116,8 @@ module.exports.getParameterValue = function (version, parameter, pathKeys, match
   return val;
 };
 
-module.exports.parseQueryString = function(req) {
-  return req.url.indexOf('?') > -1 ? qs.parse(parseurl(req).query, {}) : {};
+module.exports.parseQueryString = function(req, options) {
+  return req.url.indexOf('?') > -1 ? qs.parse(parseurl(req).query, options || {}) : {};
 };
 
 module.exports.debugError = function (err, debug) {

--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -466,10 +466,11 @@ var processSwaggerDocuments = function (rlOrSO, apiDeclarations) {
  *
  * @param {object} rlOrSO - The Resource Listing (Swagger 1.2) or Swagger Object (Swagger 2.0)
  * @param {object[]} apiDeclarations - The array of API Declarations (Swagger 1.2)
+ * @param {object} options - The parsers' options, which will override defaults ones
  *
  * @returns the middleware function
  */
-exports = module.exports = function (rlOrSO, apiDeclarations) {
+exports = module.exports = function (rlOrSO, apiDeclarations, options) {
   debug('Initializing swagger-metadata middleware');
 
   var apiCache = processSwaggerDocuments(rlOrSO, apiDeclarations);
@@ -487,6 +488,22 @@ exports = module.exports = function (rlOrSO, apiDeclarations) {
     } else if (!_.isArray(apiDeclarations)) {
       throw new TypeError('apiDeclarations must be an array');
     }
+  } else {
+    options = apiDeclarations;
+  }
+  
+  // Use options if any
+  if (options.jsonBodyParserOptions) {
+    jsonBodyParser = bp.json(options.jsonBodyParserOptions);
+  }
+  if (options.bodyParserOptions) {
+    urlEncodedBodyParser = bp.urlencoded(options.bodyParserOptions);
+  }
+  if (options.multerOptions) {
+    multiPartParser = multer(options.multerOptions);    
+  }
+  if (options.textBodyParserOptions) {
+    realTextBodyParser = bp.text(options.textBodyParserOptions);
   }
 
   return function swaggerMetadata (req, res, next) {

--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -493,16 +493,16 @@ exports = module.exports = function (rlOrSO, apiDeclarations, options) {
   }
   
   // Use options if any
-  if (options.jsonBodyParserOptions) {
+  if (options && options.jsonBodyParserOptions) {
     jsonBodyParser = bp.json(options.jsonBodyParserOptions);
   }
-  if (options.bodyParserOptions) {
+  if (options && options.bodyParserOptions) {
     urlEncodedBodyParser = bp.urlencoded(options.bodyParserOptions);
   }
-  if (options.multerOptions) {
+  if (options && options.multerOptions) {
     multiPartParser = multer(options.multerOptions);    
   }
-  if (options.textBodyParserOptions) {
+  if (options && options.textBodyParserOptions) {
     realTextBodyParser = bp.text(options.textBodyParserOptions);
   }
 

--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -44,12 +44,13 @@ var multerOptions = {
 var textBodyParserOptions = {
   type: '*/*'
 };
+var qsOptions = {};
 
 var jsonBodyParser = bp.json();
 var parseQueryString = mHelpers.parseQueryString;
 var queryParser = function (req, res, next) {
   if (_.isUndefined(req.query)) {
-    req.query = parseQueryString(req);
+    req.query = parseQueryString(req, qsOptions);
   }
 
   return next();
@@ -504,6 +505,9 @@ exports = module.exports = function (rlOrSO, apiDeclarations, options) {
   }
   if (options && options.textBodyParserOptions) {
     realTextBodyParser = bp.text(options.textBodyParserOptions);
+  }
+  if (options && options.qsOptions) {
+    qsOptions = options.qsOptions;
   }
 
   return function swaggerMetadata (req, res, next) {


### PR DESCRIPTION
With the upgrade to multer 1.x, if you want to use `diskStorage` instead of `memoryStorage`, you can no longer just add a global multer on all routes before swagger-tools/middleware, since `multer#fields` need all parameter names.

I think that in most case, only the multer part will be used, but why not allow customization of the other parsers ?