### PR TITLE
Configure expressjs/body-parser to accept custom JSON types

### DIFF
--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -45,7 +45,9 @@ var textBodyParserOptions = {
   type: '*/*'
 };
 
-var jsonBodyParser = bp.json();
+var jsonBodyParser = bp.json({
+  type: ['json', 'application/*+json']
+});
 var parseQueryString = mHelpers.parseQueryString;
 var queryParser = function (req, res, next) {
   if (_.isUndefined(req.query)) {


### PR DESCRIPTION
Custom JSON types cause a validation error for body parameters. For example, using the [JSON API content type "application/vnd.api+json"](
http://jsonapi.org/format/#content-negotiation), triggers an error with the code SCHEMA_VALIDATION_FAILED. However, the exact same request and response will correctly validate using "application/json".

The problem is that swagger-tools needs to configure expressjs/body-parser to accept custom JSON types. The expressjs/body-parser readme provides an example of this exact case: https://github.com/expressjs/body-parser#change-content-type-for-parsers.
