### PR TITLE
Improve swagger-router controller error handling.

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -30,6 +30,7 @@ var debug = require('debug')('swagger-tools:middleware:router');
 var fs = require('fs');
 var mHelpers = require('./helpers');
 var path = require('path');
+var util = require('util');
 
 var defaultOptions = {
   controllers: {},
@@ -77,26 +78,39 @@ var handlerCacheFromDir = function (dirOrDirs) {
       var controller;
 
       if (file.match(jsFileRegex)) {
-        controller = require(path.resolve(path.join(dir, controllerName)));
+        try {
+          controller = require(path.resolve(path.join(dir, controllerName)));
 
-        debug('    %s%s:',
+          debug('    %s%s:',
+                path.resolve(path.join(dir, file)),
+                (_.isPlainObject(controller) ? '' : ' (not an object, skipped)'));
+
+          if (_.isPlainObject(controller)) {
+            _.each(controller, function (value, name) {
+              var handlerId = controllerName + '_' + name;
+
+              debug('      %s%s',
+                    handlerId,
+                    (_.isFunction(value) ? '' : ' (not a function, skipped)'));
+
+              // TODO: Log this situation
+
+              if (_.isFunction(value) && !handlerCache[handlerId]) {
+                handlerCache[handlerId] = value;
+              }
+            });
+          }
+        } catch (err) {
+          // TODO: Change this logging to match the above when the overall
+          // logging piece is done.
+          var message = util.format('%s - Module loader error: %s',
               path.resolve(path.join(dir, file)),
-              (_.isPlainObject(controller) ? '' : ' (not an object, skipped)'));
-
-        if (_.isPlainObject(controller)) {
-          _.each(controller, function (value, name) {
-            var handlerId = controllerName + '_' + name;
-
-            debug('      %s%s',
-                  handlerId,
-                  (_.isFunction(value) ? '' : ' (not a function, skipped)'));
-
-            // TODO: Log this situation
-
-            if (_.isFunction(value) && !handlerCache[handlerId]) {
-              handlerCache[handlerId] = value;
-            }
-          });
+              err);
+          debug('    %s', message);
+          if (console) {
+            console.log(message);
+          }
+          throw err;
         }
       }
     });


### PR DESCRIPTION
Changes to swagger-router to add additional logging when a require() on a controller module fails:

- Always logs to console if present, since this error is fatal.
- Additionally log to debug() with same message to allow any debug message sinks to continue to operate and track error too.

I deliberately re-throw the error so as not to change the control flow. Today the error just goes straight to the top of the stack, this continues the behaviour, but at least gives a reason why.

-Steve