### PR TITLE
Fix issue where validation is failing when matching a "pattern" prope…

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -616,7 +616,11 @@ var validateSchemaConstraints = module.exports.validateSchemaConstraints = funct
     }
 
     if (type === 'array') {
-      _.each(val, function (val, index) {
+      var array_val = val
+      if (typeof val == 'string') {
+        array_val = JSON.parse(val)
+      } 
+      _.each(array_val, function (val, index) {
         try {
           validateSchemaConstraints(version, schema.items || {}, path.concat(index.toString()), val);
         } catch (err) {


### PR DESCRIPTION
…rty against a set of a array items.

E.g. If we try to match [["abc", "abbbc", "abbbbbbbc"]] against the schema below it fails since it's trying to match ab+c against the string value '[["abc", "abbbc", "abbbbbbbc"]]'

```
paths:
  /tags:
    x-swagger-router-controller: tags
    get:
      summary: Get All Tags
      description: Retrieves a list of all available tags.
      operationId: get_all_tags
      responses:
        200:
          description: OK
          schema:
            type: array
            items:
              type: array
              items:
                type: string
                pattern: ab+c
```