### PR TITLE
Fix empty responses & properly handle file buffers

### DIFF
--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -31,6 +31,20 @@ var debug = require('debug')('swagger-tools:middleware:validator');
 var mHelpers = require('./helpers');
 var validators = require('../lib/validators');
 
+var checkIsFile = function (schema, version) {
+  var isFile = false;
+  if (version === '1.2') {
+    var type = (schema.items ? schema.items.type || schema.items.$ref : schema.type);
+    isFile = type === 'file';
+  }
+  else {
+    if (!_.isUndefined(schema.schema)) {
+      isFile = schema.schema.type === 'file';
+    }
+  }
+  return isFile;
+};
+
 var sendData = function (swaggerVersion, res, data, encoding, skipped) {
   // 'res.end' requires a Buffer or String so if it's not one, create a String
   if (!(data instanceof Buffer) && !_.isString(data)) {
@@ -201,6 +215,11 @@ var wrapEnd = function (req, res, next) {
         val = data;
       }
     }
+    else if(writtenData.length === 0) {
+      // Some code expects val to be undefined and not an empty string
+      // when no data is passed to 'end' or written with 'write'.
+      val = undefined; 
+    } 
     else if(writtenData) {
       val = Buffer.concat(writtenData);
     }
@@ -214,9 +233,6 @@ var wrapEnd = function (req, res, next) {
     debug('  Response validation:');
 
     // If the data is a buffer, convert it to a string so we can parse it prior to validation
-    if (val instanceof Buffer) {
-      val = val.toString(encoding);
-    }
 
     // Express removes the Content-Type header from 204/304 responses which makes response validation impossible
     if (_.isUndefined(res.getHeader('content-type')) && [204, 304].indexOf(res.statusCode) > -1) {
@@ -279,6 +295,11 @@ var wrapEnd = function (req, res, next) {
       if (_.isUndefined(schema)) {
         sendData(swaggerVersion, res, val, encoding, true);
       } else {
+        // If the data is a buffer, convert it to a string so we can parse it prior to validation
+        var isFile = checkIsFile(schema, req.swagger.apiDeclaration ? '1.2' : '2.0');
+        if (val instanceof Buffer && !isFile) {
+          val = val.toString(encoding);
+        }
         validateValue(req, schema, vPath, val, function (err) {
           if (err) {
             throw err;

--- a/test/2.0/test-middleware-swagger-validator.js
+++ b/test/2.0/test-middleware-swagger-validator.js
@@ -1130,8 +1130,46 @@ describe('Swagger Validator Middleware v2.0', function () {
           ], done));
       });
     });
-    
-    
+        
+    it('should not return an error with a null schema on an empty response', function (done) {
+      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      
+      cPetStoreJson.paths['/redirect'] = {
+        'get': {
+          'x-swagger-router-controller': 'Test',
+          'operationId': 'redirectTest',
+          'responses': {
+            '302': {
+              'description': 'Redirect'
+            }
+          }
+        }
+      };
+
+      helpers.createServer([cPetStoreJson], {
+        swaggerRouterOptions: {
+          controllers: {
+            'Test_redirectTest': function (req, res) {
+              res.statusCode = 302;
+              res.end();
+            }
+          }
+        },
+        swaggerValidatorOptions: {
+          validateResponse: true
+        }
+      }, function (app) {
+        request(app)
+          .get('/api/redirect')
+          .expect(302)
+          .end(function (err, res) {
+            if (err) {
+              throw err + '\n' + res.error.text;
+            }
+            done();
+          });
+      });
+    });
     
     it('should validate a valid piped response', function (done) {
       var cPetStoreJson = _.cloneDeep(petStoreJson);


### PR DESCRIPTION
Added a failing test case that will check to see if a redirect with null schema is failing validation.

Added code to ensure unit test passes by doing a check if no data is passed to end and no data is written. In this situation some code expects undefined to be passed to the validators.

Delay converting response buffers to string as long as possible. Also, don't convert buffers sourced from a file to a string as it'll mess with the encoding. There's nothing to validate on files anyway.
