### PR TITLE
Update swagger-validator.js

### DIFF
--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -105,7 +105,7 @@ var send400 = function (req, res, next, err) {
     err.stack = err.stack.replace(currentMessage, validationMessage);
   }
 
-  return next(err);
+  return res.status(400).send(err);
 };
 var validateValue = function (req, schema, path, val, callback) {
   var document = req.swagger.apiDeclaration || req.swagger.swaggerObject;


### PR DESCRIPTION
Should return error properly.
When using [supertest](https://github.com/visionmedia/supertest) and sending request body that does not match the swagger, it doesn't return any response