### PR TITLE
Added ability to (optionally) set the swagger-metadata Multer options

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,10 +84,10 @@ var initializeMiddleware = function initializeMiddleware (rlOrSO, resources, cal
 
       callback({
         // Create a wrapper to avoid having to pass the non-optional arguments back to the swaggerMetadata middleware
-        swaggerMetadata: function () {
+        swaggerMetadata: function (options) {
           var swaggerMetadata = require('./middleware/swagger-metadata');
 
-          return swaggerMetadata.apply(undefined, args.slice(0, args.length - 1));
+          return swaggerMetadata.apply(undefined, [args[0], args.length > 2? args[1] : undefined, options]);
         },
         swaggerRouter: require('./middleware/swagger-router'),
         swaggerSecurity: require('./middleware/swagger-security'),

--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -34,12 +34,15 @@ var multer = require('multer');
 var parseurl = require('parseurl');
 var pathToRegexp = require('path-to-regexp');
 
+var defaultOptions = {
+  multer: {
+    storage: multer.memoryStorage()
+  }
+};
+
 // Upstream middlewares
 var bodyParserOptions = {
   extended: false
-};
-var multerOptions = {
-  storage: multer.memoryStorage()
 };
 var textBodyParserOptions = {
   type: '*/*'
@@ -76,7 +79,7 @@ var bodyParser = function (req, res, next) {
     next();
   }
 };
-var realMultiPartParser = multer(multerOptions);
+var realMultiPartParser = multer(defaultOptions.multer);
 var makeMultiPartParser = function (parser) {
   return function (req, res, next) {
     if (_.isUndefined(req.files)) {
@@ -113,11 +116,11 @@ var expressStylePath = function (basePath, apiPath) {
 var processOperationParameters = function (swaggerMetadata, pathKeys, pathMatch, req, res, next) {
   var version = swaggerMetadata.swaggerVersion;
   var spec = cHelpers.getSpec(cHelpers.getSwaggerVersion(version === '1.2' ?
-                                                         swaggerMetadata.resourceListing :
-                                                         swaggerMetadata.swaggerObject), true);
+    swaggerMetadata.resourceListing :
+    swaggerMetadata.swaggerObject), true);
   var parameters = !_.isUndefined(swaggerMetadata) ?
-                     (version === '1.2' ? swaggerMetadata.operation.parameters : swaggerMetadata.operationParameters) :
-                     undefined;
+    (version === '1.2' ? swaggerMetadata.operation.parameters : swaggerMetadata.operationParameters) :
+    undefined;
 
   if (!parameters) {
     return next();
@@ -179,14 +182,16 @@ var processOperationParameters = function (swaggerMetadata, pathKeys, pathMatch,
 
     return fields;
   }, []);
-  
+
   var contentType = req.headers['content-type'];
-  if (multiPartFields.length) {
-    // If there are files, use multer#fields
-    parsers.push(makeMultiPartParser(realMultiPartParser.fields(multiPartFields)));
-  } else if (contentType && contentType.split(';')[0] === 'multipart/form-data') {
-    // If no files but multipart form, use empty multer#array for text fields
-    parsers.push(makeMultiPartParser(realMultiPartParser.array()));
+  if (realMultiPartParser) {
+    if (multiPartFields.length) {
+      // If there are files, use multer#fields
+      parsers.push(makeMultiPartParser(realMultiPartParser.fields(multiPartFields)));
+    } else if (contentType && contentType.split(';')[0] === 'multipart/form-data') {
+      // If no files but multipart form, use empty multer#array for text fields
+      parsers.push(makeMultiPartParser(realMultiPartParser.array()));
+    }
   }
 
   async.map(parsers, function (parser, callback) {
@@ -366,10 +371,13 @@ var processSwaggerDocuments = function (rlOrSO, apiDeclarations) {
  *
  * @param {object} rlOrSO - The Resource Listing (Swagger 1.2) or Swagger Object (Swagger 2.0)
  * @param {object[]} apiDeclarations - The array of API Declarations (Swagger 1.2)
+ * @param {object} module options. Optional.
+ *                 multer: multipart/form-data middleware options (see https://github.com/expressjs/multer).
+ *                         Defaults to memoryStorage
  *
  * @returns the middleware function
  */
-exports = module.exports = function (rlOrSO, apiDeclarations) {
+exports = module.exports = function (rlOrSO, apiDeclarations, options) {
   debug('Initializing swagger-metadata middleware');
 
   var apiCache = processSwaggerDocuments(rlOrSO, apiDeclarations);
@@ -388,6 +396,9 @@ exports = module.exports = function (rlOrSO, apiDeclarations) {
       throw new TypeError('apiDeclarations must be an array');
     }
   }
+
+  options = _.defaults(options || {}, defaultOptions);
+  realMultiPartParser = options.multer? multer(options.multer) : null;
 
   return function swaggerMetadata (req, res, next) {
     var method = req.method.toLowerCase();


### PR DESCRIPTION
Added ability to (optionally) specify the swagger-metadata Multer options

The multer middleware handles multipart/form-data using memoryStorage by default. Can now be redefined (see https://github.com/expressjs/multer). Alternatively, it can be defined as null to completely skip multipart/form-data parsing. In that case another middleware or the route handler would need to take care of it