### PR TITLE
pass an actual schema to the mHelpers.convertValue

### DIFF
--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -113,7 +113,7 @@ var validateValue = function (req, schema, path, val, callback) {
   var isModel = mHelpers.isModelParameter(version, schema);
   var spec = cHelpers.getSpec(version);
 
-  val = mHelpers.convertValue(val, schema, mHelpers.getParameterType(schema));
+  val = mHelpers.convertValue(val, schema.schema ? schema.schema : schema, mHelpers.getParameterType(schema));
 
   try {
     validators.validateSchemaConstraints(version, schema, path, val);

--- a/test/2.0/test-middleware-swagger-validator.js
+++ b/test/2.0/test-middleware-swagger-validator.js
@@ -1570,5 +1570,62 @@ describe('Swagger Validator Middleware v2.0', function () {
         }
       });      
     });
+
+    it('should consume/return array of strings if they are numeric (Issue 380)', function (done) {
+      var swaggerObject = _.cloneDeep(petStoreJson);
+
+      swaggerObject.paths['/tags'] = {
+        post: {
+          consumes: ['application/json; charset=utf-8'],
+          produces: ['application/json; charset=utf-8'],
+          summary: 'Save Tags',
+          description: 'save a list of tags.',
+          operationId: 'saveStringTags',
+          parameters: [
+            {
+              name: 'tags',
+              in: 'body',
+              description: 'tags',
+              required: true,
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              }
+            }
+          ],
+          responses: {
+            '200': {
+              description: 'OK',
+              schema: {
+                type: 'array',
+                items: {
+                  type: 'string'
+                }
+              }
+            }
+          }
+        }
+      };
+      var tags = ['somephotourl', '123'];
+      helpers.createServer([swaggerObject], {
+        swaggerRouterOptions: {
+          controllers: {
+            saveStringTags: function (req, res) {
+              res.end(JSON.stringify(req.swagger.params.tags.value));
+            }
+          }
+        }
+      }, function (app) {
+        //
+        request(app)
+          .post('/api/tags')
+          .set('content-type', 'application/json; charset=utf-8')
+          .send(tags)
+          .expect(200)
+          .end(helpers.expectContent(tags, done));
+      });
+    });
   });
 });


### PR DESCRIPTION
It is a fix proposal for the issue described here https://github.com/apigee-127/swagger-tools/issues/380.
Swagger validator sometimes doesn't pass actual parameter's schema in the `mHelpers.convertValue`, so the value can be converted incorrectly. I added test case, without the fix it fails.