### PR TITLE
Invalid content type error fix

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -245,7 +245,7 @@ module.exports.validateContentType = function (gPOrC, oPOrC, reqOrRes) {
   if (pOrC.length > 0 && (isResponse ?
                           true :
                           ['POST', 'PUT'].indexOf(reqOrRes.method) !== -1) && pOrC.indexOf(contentType) === -1) {
-    throw new Error('Invalid content type (' + contentType + ').  These are valid: ' + pOrC.join(', '));
+    throwErrorWithCode('INVALID_TYPE', 'Invalid content type (' + contentType + ').  These are valid: ' + pOrC.join(', '));
   }
 };
 

--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -62,47 +62,53 @@ var send400 = function (req, res, next, err) {
   // Format the errors to include the parameter information
   if (err.failedValidation === true) {
     currentMessage = err.message;
-    validationMessage = 'Parameter (' + err.paramName + ') ';
 
-    switch (err.code) {
-    case 'ENUM_MISMATCH':
-    case 'MAXIMUM':
-    case 'MAXIMUM_EXCLUSIVE':
-    case 'MINIMUM':
-    case 'MINIMUM_EXCLUSIVE':
-    case 'MULTIPLE_OF':
-    case 'INVALID_TYPE':
-      if (err.code === 'INVALID_TYPE' && err.message.split(' ')[0] === 'Value') {
+    if(err.paramName) {
+      validationMessage = 'Parameter (' + err.paramName + ') ';
+
+      switch (err.code) {
+      case 'ENUM_MISMATCH':
+      case 'MAXIMUM':
+      case 'MAXIMUM_EXCLUSIVE':
+      case 'MINIMUM':
+      case 'MINIMUM_EXCLUSIVE':
+      case 'MULTIPLE_OF':
+      case 'INVALID_TYPE':
+        if (err.code === 'INVALID_TYPE' && err.message.split(' ')[0] === 'Value') {
+          validationMessage += err.message.split(' ').slice(1).join(' ');
+        } else {
+          validationMessage += 'is ' + err.message.charAt(0).toLowerCase() + err.message.substring(1);
+        }
+
+        break;
+
+      case 'ARRAY_LENGTH_LONG':
+      case 'ARRAY_LENGTH_SHORT':
+      case 'MAX_LENGTH':
+      case 'MIN_LENGTH':
         validationMessage += err.message.split(' ').slice(1).join(' ');
-      } else {
-        validationMessage += 'is ' + err.message.charAt(0).toLowerCase() + err.message.substring(1);
+
+        break;
+
+      case 'MAX_PROPERTIES':
+      case 'MIN_PROPERTIES':
+        validationMessage += 'properties are ' + err.message.split(' ').slice(4).join(' ');
+
+        break;
+
+      default:
+        validationMessage += err.message.charAt(0).toLowerCase() + err.message.substring(1);
       }
 
-      break;
+      // Replace the stack message
+      err.stack = err.stack.replace(currentMessage, validationMessage);
 
-    case 'ARRAY_LENGTH_LONG':
-    case 'ARRAY_LENGTH_SHORT':
-    case 'MAX_LENGTH':
-    case 'MIN_LENGTH':
-      validationMessage += err.message.split(' ').slice(1).join(' ');
-
-      break;
-
-    case 'MAX_PROPERTIES':
-    case 'MIN_PROPERTIES':
-      validationMessage += 'properties are ' + err.message.split(' ').slice(4).join(' ');
-
-      break;
-
-    default:
-      validationMessage += err.message.charAt(0).toLowerCase() + err.message.substring(1);
+    } else {
+        validationMessage = currentMessage;
     }
 
     // Replace the message
     err.message = 'Request validation failed: ' + validationMessage;
-
-    // Replace the stack message
-    err.stack = err.stack.replace(currentMessage, validationMessage);
   }
 
   return next(err);

--- a/test/1.2/test-middleware-swagger-validator.js
+++ b/test/1.2/test-middleware-swagger-validator.js
@@ -69,7 +69,7 @@ describe('Swagger Validator Middleware v1.2', function () {
         request(app)
           .post('/api/pet/1')
           .expect(400)
-          .end(helpers.expectContent('Invalid content type (application/octet-stream).  These are valid: ' +
+          .end(helpers.expectContent('Request validation failed: Invalid content type (application/octet-stream).  These are valid: ' +
                                     'application/x-www-form-urlencoded', done));
       });
     });
@@ -1114,7 +1114,7 @@ describe('Swagger Validator Middleware v1.2', function () {
           ], done));
       });
     });
-    
+
     it('should validate a valid piped response', function (done) {
       var cPetJson = _.cloneDeep(petJson);
 
@@ -1141,7 +1141,7 @@ describe('Swagger Validator Middleware v1.2', function () {
           .end(helpers.expectContent(samplePet, done));
       });
     });
-    
+
     it('should validate an invalid piped response', function (done) {
       var cPetJson = _.cloneDeep(petJson);
 

--- a/test/2.0/test-middleware-swagger-validator.js
+++ b/test/2.0/test-middleware-swagger-validator.js
@@ -74,7 +74,7 @@ describe('Swagger Validator Middleware v2.0', function () {
             name: 'Fake Pet'
           })
           .expect(400)
-          .end(helpers.expectContent('Invalid content type (application/json).  These are valid: ' +
+          .end(helpers.expectContent('Request validation failed: Invalid content type (application/json).  These are valid: ' +
                                        'application/xml', done));
       });
     });


### PR DESCRIPTION
If the user submits an invalid content type, the swagger validator doesn't set the failedValidation field in the error object.