### PR TITLE
Add support for nested controllers

### DIFF
--- a/samples/2.0/petstore.json
+++ b/samples/2.0/petstore.json
@@ -155,6 +155,43 @@
           "format": "int64"
         }
       ]
+    },
+    "/pets/{id}/custom": {
+      "x-swagger-router-controller": "nested-controllers/CustomPets",
+      "get": {
+        "security": [
+          {
+            "oauth2": ["read"]
+          }
+        ],
+        "tags": [ "Pet Operations" ],
+        "operationId": "getAllPetsCustom",
+        "summary": "Finds the pet by id",
+        "responses": {
+          "200": {
+            "description": "Pet response",
+            "schema": {
+              "$ref": "#/definitions/Pet"
+            }
+          },
+          "default": {
+            "description": "Unexpected error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "description": "ID of pet",
+          "required": true,
+          "type": "integer",
+          "format": "int64"
+        }
+      ]
     }
   },
   "definitions": {

--- a/test/2.0/test-middleware-swagger-router.js
+++ b/test/2.0/test-middleware-swagger-router.js
@@ -118,6 +118,22 @@ describe('Swagger Router Middleware v2.0', function () {
     });
   });
 
+  it('should do routing when options.controllers is a valid array of directory paths with nested paths', function (done) {
+    helpers.createServer([petStoreJson], {
+      swaggerRouterOptions: {
+        controllers: [
+          path.join(__dirname, '..', 'controllers'),
+          path.join(__dirname, '..', 'controllers2')
+        ]
+      }
+    }, function (app) {
+      request(app)
+        .get('/api/pets/1/custom')
+        .expect(200)
+        .end(helpers.expectContent(require('../controllers/nested-controllers/CustomPets').response, done));
+    });
+  });
+
   it('should do routing when options.controllers is a valid controller map', function (done) {
     var cPetStoreJson = _.cloneDeep(petStoreJson);
     var controller = require('../controllers/Users');

--- a/test/controllers/nested-controllers/CustomPets.js
+++ b/test/controllers/nested-controllers/CustomPets.js
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Apigee Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
+var response = module.exports.response = 'controllers/nested-controllers/CustomPets swagger-router OK';
+
+module.exports.getAllPetsCustom = module.exports._getAllPetsCustom = function getAllPets (req, res) {
+  res.end(response);
+};


### PR DESCRIPTION
Support for nested controllers with backwards compatibility.

With the default `/api/controllers` directory, any top level controller files will get added as previous, but now also any controllers in nested directories.

The `x-swagger-router-controller` value should be a path to the controller, relative to the folder specified in `options.controllers`:

So with the default controllers folder, a controller at `api/controllers/my-service/serviceController.js` would be referenced with:

`x-swagger-router-controller: my-service/serviceController`

You can add a custom controller directory to swagger, say `controllers/custom`, and a controller at `controllers/custom/context/contextController` would be referenced with:

`x-swagger-router-controller: context/contextController`

All controller directories will be traversed fully.

Linting and tests passed, and I've added an extra test for nested controllers using `x-swagger-router-controller` in `v2.0.0.`.

This addresses https://github.com/apigee-127/swagger-tools/issues/283 and replaces https://github.com/apigee-127/swagger-tools/pull/315