### PR TITLE
suggestion: mark response validation errors

### DIFF
--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -291,6 +291,7 @@ var wrapEnd = function (req, res, next) {
     } catch (err) {
       if (err.failedValidation) {
         err.originalResponse = data;
+        err.responseValidation = true;
         err.message = 'Response validation failed: ' + err.message.charAt(0).toLowerCase() + err.message.substring(1);
 
         debug('    Validation: failed');


### PR DESCRIPTION
As input errors generate a different response code and are handled differently, make it easy to distinguish them from another by adding
`err.responseValidation = true`
to the error object.

This allows to simply do something like this:
```
if(err.failedValidation) {
  if(err.responseValidation) {
    res.statusCode = 500;
    res.end("Internal Error");
  } else {
    res.statusCode = 400;
    res.end("Input Error");
  }
}
```