### PR TITLE
Allow relative controller paths

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -86,6 +86,8 @@ var handlerCacheFromDir = function (dirOrDirs) {
         var controller;
 
         if (file.match(jsFileRegex)) {
+
+          file = path.resolve(file);
           controller = require(file);
 
           debug('    %s%s:', file, (_.isPlainObject(controller) ? '' : ' (not an object, skipped)'));
@@ -101,6 +103,9 @@ var handlerCacheFromDir = function (dirOrDirs) {
                 var handlerExists = false;
 
                 _.each(dirs, function(topLevel) {
+                  controllerName = path.resolve(controllerName);
+                  topLevel = path.resolve(topLevel);
+
                   if(controllerName.indexOf(topLevel) === 0) {
                     var relativeController = controllerName.substr(topLevel.length + 1);
                     handlerId = getFullQualifiedHandlerId(relativeController, name);
@@ -368,6 +373,7 @@ var send405 = function (req, res, next) {
  * @returns the middleware function
  */
 exports = module.exports = function (options) {
+
   var handlerCache = {};
 
   debug('Initializing swagger-router middleware');

--- a/test/1.2/test-middleware-swagger-router.js
+++ b/test/1.2/test-middleware-swagger-router.js
@@ -119,6 +119,22 @@ describe('Swagger Router Middleware v1.2', function () {
     });
   });
 
+  it('should do routing when options.controllers is a valid array of relative directory paths', function (done) {
+    helpers.createServer([rlJson, [petJson, storeJson, userJson]], {
+      swaggerRouterOptions: {
+        controllers: [
+          './test/controllers',
+          './test/controllers2'
+        ]
+      }
+    }, function (app) {
+      request(app)
+      .get('/api/user/1')
+      .expect(200)
+      .end(helpers.expectContent(require('../controllers/Users').response, done));
+    });
+  });
+
   it('should do routing when options.controllers is a valid controller map', function (done) {
     var controller = require('../controllers/Users');
 

--- a/test/2.0/test-middleware-swagger-router.js
+++ b/test/2.0/test-middleware-swagger-router.js
@@ -134,6 +134,38 @@ describe('Swagger Router Middleware v2.0', function () {
     });
   });
 
+  it('should do routing when options.controllers is a valid array of relative directory paths', function (done) {
+    helpers.createServer([petStoreJson], {
+      swaggerRouterOptions: {
+        controllers: [
+          './test/controllers',
+          './test/controllers2'
+        ]
+      }
+    }, function (app) {
+      request(app)
+      .get('/api/pets/1')
+      .expect(200)
+      .end(helpers.expectContent(require('../controllers/Pets').response, done));
+    });
+  });
+
+  it('should do routing when options.controllers is a valid array of relative directory paths with nested paths', function (done) {
+    helpers.createServer([petStoreJson], {
+      swaggerRouterOptions: {
+        controllers: [
+          './test/controllers',
+          './test/controllers2'
+        ]
+      }
+    }, function (app) {
+      request(app)
+      .get('/api/pets/1/custom')
+      .expect(200)
+      .end(helpers.expectContent(require('../controllers/nested-controllers/CustomPets').response, done));
+    });
+  });
+
   it('should do routing when options.controllers is a valid controller map', function (done) {
     var cPetStoreJson = _.cloneDeep(petStoreJson);
     var controller = require('../controllers/Users');


### PR DESCRIPTION
This fixes the issue raised after the merge of https://github.com/apigee-127/swagger-tools/pull/422

I've added additional tests that point to the same controller operations but using relative paths instead of absolute ones. 

@bitcloud - are you able to confirm that this fixes the issue? (And thanks for spotting this and suggesting the fix).