### PR TITLE
Modified helpers.js, swagger-metadata.js added body flag to convertValue so it will not convert to an array if the body is object

### DIFF
--- a/middleware/helpers.js
+++ b/middleware/helpers.js
@@ -164,7 +164,7 @@ module.exports.debugError = function (err, debug) {
   }
 };
 
-var convertValue = module.exports.convertValue = function (value, schema, type, body) {
+var convertValue = module.exports.convertValue = function (value, schema, type) {
   var original = value;
 
   // Default to {}
@@ -219,7 +219,7 @@ var convertValue = module.exports.convertValue = function (value, schema, type, 
     }
 
     // Handle situation where the expected type is array but only one value was provided
-    if (!_.isArray(value) && (body === undefined || body === false)) {
+    if (!_.isArray(value)) {
       value = [value];
     }
 

--- a/middleware/helpers.js
+++ b/middleware/helpers.js
@@ -164,7 +164,7 @@ module.exports.debugError = function (err, debug) {
   }
 };
 
-var convertValue = module.exports.convertValue = function (value, schema, type) {
+var convertValue = module.exports.convertValue = function (value, schema, type, body) {
   var original = value;
 
   // Default to {}
@@ -219,7 +219,7 @@ var convertValue = module.exports.convertValue = function (value, schema, type) 
     }
 
     // Handle situation where the expected type is array but only one value was provided
-    if (!_.isArray(value)) {
+    if (!_.isArray(value) && (body === undefined || body === false)) {
       value = [value];
     }
 

--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -207,7 +207,7 @@ var processOperationParameters = function (swaggerMetadata, pathKeys, pathMatch,
 
       // Located here to make the debug output pretty
       oVal = mHelpers.getParameterValue(version, parameter, pathKeys, pathMatch, req, debug);
-      value = mHelpers.convertValue(oVal, _.isUndefined(parameter.schema) ? parameter : parameter.schema, pType);
+      value = mHelpers.convertValue(oVal, _.isUndefined(parameter.schema) ? parameter : parameter.schema, pType, parameter.in === 'body');
 
       debug('      Value: %s', value);
 

--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -207,7 +207,17 @@ var processOperationParameters = function (swaggerMetadata, pathKeys, pathMatch,
 
       // Located here to make the debug output pretty
       oVal = mHelpers.getParameterValue(version, parameter, pathKeys, pathMatch, req, debug);
-      value = mHelpers.convertValue(oVal, _.isUndefined(parameter.schema) ? parameter : parameter.schema, pType, parameter.in === 'body');
+
+      if (!_.isArray(oVal) && parameter.in === 'body' && parameter.schema && parameter.schema.type === 'array') {
+        var err = new Error('Failed schema validation - expected an array but received an object');
+
+        err.code = 'SCHEMA_VALIDATION_FAILED';
+        err.failedValidation = true;
+
+        return next(err);
+      }
+
+      value = mHelpers.convertValue(oVal, _.isUndefined(parameter.schema) ? parameter : parameter.schema, pType);
 
       debug('      Value: %s', value);
 


### PR DESCRIPTION
Ref : https://github.com/apigee-127/swagger-tools/issues/438
