### PR TITLE
fixes security test order

### DIFF
--- a/middleware/swagger-security.js
+++ b/middleware/swagger-security.js
@@ -131,7 +131,7 @@ exports = module.exports = function (options) {
       req.swagger.operation.security || req.swagger.swaggerObject.security;
 
       if (securityReqs && securityReqs.length > 0) {
-        async.map(securityReqs, function (secReq, cb) { // logical OR - any one can allow
+        async.mapSeries(securityReqs, function (secReq, cb) { // logical OR - any one can allow
           var secName;
 
           async.map(Object.keys(secReq), function (name, cb) { // logical AND - all must allow


### PR DESCRIPTION
this pull request fixes the security testing order. Imagine a security-setup like this
```
  security:
    -
      client_credentials: []
      user_credentials: []
    -
      client_credentials: []
```
I want to process the security definitions in order so that satisfying client_credentials AND user_credentials always wins.
Appearently this does not resolve reliable until now since the security middleware invokes the security handlers with `async.map()` so that both OR-sets are tried to resolve in parallel, so that sometimes wins the first, sometimes the second. 
In my usecase i save client- and user-credentials to the request-object so that i do not have to do it again in the controller. with this pull request i changed the implementation to work sequentially for the OR-set by using `async.mapSeries` instead of `async.map`. this ensures that testing the first set has to finish in order to test the second one. also the second set is never invoked if the first satisfys successfully.

i hope i could make myself clear. feel free to include the docker-stuff. i find it convenient, but not necessary. 