### PR TITLE
added docker-compose support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+  node:
+    image: docker.io/smoebody/dev-nodejs:6
+    volumes:
+      - ./:/app:z
+      - npm-cache:/home/dev/.npm:z
+    ports:
+      - 127.0.0.1:5858:5858
+    environment:
+      - NODE_ENV=development
+    command: 
+      - npm test
+
+volumes:
+  npm-cache: {}


### PR DESCRIPTION
with this one can use docker and docker-compose to set up a simple dev-environment, means not having nodejs on his computer.

    docker-compose run --rm node npm install

calls `npm install` inside the docker container

    docker-compose run --rm node

calls `npm test` - the default command - and runs all gulp-tasks. 

    docker-compose run --rm --service-ports node node --debug-brk node_modules/.bin/gulp

calls the gulp-script with node's debug-option. connect your debug-client to localhost:5858.

The option `--rm` ensures that the container is thrown away after command exits.