### PR TITLE
added debug call to npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Various tools for using and integrating with Swagger.",
   "main": "index.js",
   "scripts": {
-    "test": "gulp"
+    "test": "gulp",
+    "test-debug": "node --debug-brk node_modules/.bin/gulp"
   },
   "author": {
     "name": "Jeremy Whitlock",


### PR DESCRIPTION
this simply adds a script call `test-debug` to npm's package.json that starts the gulp-script with node's debug option.

    npm run test-debug

starts the gulp-script and waits for a debug-client to connect.

the reason why i do this by explicitly calling node is, because gulp does not offer a debug option itself