### PR TITLE
Allow custom JSON Schema validator in validator middleware (fixes #467)

### DIFF
--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -406,10 +406,10 @@ configuration.  _(Note: This limitation, the need to manually create your `contr
 issues #219 and #221 are completed.)_
 
 A new option (since 0.8.4) is the addition of the `x-swagger-router-handle-subpaths` extension to the Swagger path
-component. By setting this property to `true`, it indicates to Swagger Router that it should match and route all 
-requests to not only the specified path, but also any undeclared subpaths requested that do not match an explicitly 
+component. By setting this property to `true`, it indicates to Swagger Router that it should match and route all
+requests to not only the specified path, but also any undeclared subpaths requested that do not match an explicitly
 defined path in the Swagger. While you cannot specify wildcards in Swagger, this would be the spiritual equivalent
-of wildcarding the end of the path something like `/pets/**`. For example, the following Swagger would cause 
+of wildcarding the end of the path something like `/pets/**`. For example, the following Swagger would cause
 Swagger Router to match and route `/pets`, `/pets/1`, or even `/pets/this/is/an/arbitrary/route` to the `Pets`
 controller:
 
@@ -530,8 +530,40 @@ suppose to return `application/x-yaml` but it returns `application/json`, it wil
 
 * **options:** `object` The middleware options
 * **options.validateResponse:** `[boolean=false]` Whether or not to validate responses
+* **options.schemaValidator**: `[Object]` A custom validator to use instead of the built in validator. See below for details
 
 **Returns**
+
+### Custom JSON Schema Validator
+The Swagger Validator Middleware provides built-in validation using [z-schema](https://github.com/zaggino/z-schema).  This should
+be sufficient for all cases using the official Swagger specification.
+
+If you want to use a [Vendor Extension](http://swagger.io/specification/#vendorExtensions) in the validation of
+[Schema Objects](http://swagger.io/specification/#schema-object-80), you can supply your own schema validator
+to the swagger validator middleware in `options.schemaValidator`.
+
+**WARNING:** This ONLY applies to **_schema objects_** in the body of a request or response.  All other validation
+continues to be handled by the _internal_ validators, including validation of the swagger definition itself,
+the validation of path and query parameters.
+
+A custom validator _MUST_ provide the following 2 functions in a compatible manner to z-schema's implementation:
+- `validate(json, schema)`
+- - Arguments:
+- - - **json**: `String` The JSON to be validated
+- - - **schema**: `String|Object` The JSON schema to validate against
+- - Returns:
+- - - `boolean`  returns true on successful validation, false on error
+- `getLastErrors()`
+- - Returns:
+- - - `[object[]]` An array of objects describing the error or `undefined` if no errors.
+
+A custom validator _SHOULD_ include custom format functions to support the `format`s specified in the
+[Swagger Specification](http://swagger.io/specification/#data-types-12) (i.e. `int32`, `int64`, etc.)
+as these are not included in JSON Schema and are thus not in most validators by default.
+
+Any custom `vendor extension`s (or `custom keywords`) added to the the validators MUST start with `"x-"`
+to comply with the swagger specification.  So `"x-example-keyword"` is accceptable, but `"exampleKeyword"`
+is not.  This does not apply to custom `format`s which DO NOT need to start with `"x-"`.
 
 ## Complete Example
 

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -140,27 +140,29 @@ var throwErrorWithCode = function (code, msg) {
 module.exports.validateAgainstSchema = function (schemaOrName, data, validator) {
   var sanitizeError = function (obj) {
     // Make anyOf/oneOf errors more human readable (Issue 200)
-    var defType = ['additionalProperties', 'items'].indexOf(obj.path[obj.path.length - 1]) > -1 ?
-          'schema' :
-          obj.path[obj.path.length - 2];
+    if (!_.isUndefined(obj.path) && !_.isUndefined(obj.code)) {
+      var defType = ['additionalProperties', 'items'].indexOf(obj.path[obj.path.length - 1]) > -1 ?
+        'schema' :
+        obj.path[obj.path.length - 2];
 
-    if (['ANY_OF_MISSING', 'ONE_OF_MISSING'].indexOf(obj.code) > -1) {
-      switch (defType) {
-      case 'parameters':
-        defType = 'parameter';
-        break;
+      if (['ANY_OF_MISSING', 'ONE_OF_MISSING'].indexOf(obj.code) > -1) {
+        switch (defType) {
+          case 'parameters':
+            defType = 'parameter';
+            break;
 
-      case 'responses':
-        defType = 'response';
-        break;
+          case 'responses':
+            defType = 'response';
+            break;
 
-      case 'schema':
-        defType += ' ' + obj.path[obj.path.length - 1];
+          case 'schema':
+            defType += ' ' + obj.path[obj.path.length - 1];
 
-        // no default
+          // no default
+        }
+
+        obj.message = 'Not a valid ' + defType + ' definition';
       }
-
-      obj.message = 'Not a valid ' + defType + ' definition';
     }
 
     // Remove the params portion of the error

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "schemas"
   ],
   "devDependencies": {
+    "ajv": "^4.10.3",
     "browserify": "^13.0.0",
     "connect": "^3.4.0",
     "del": "^2.2.0",

--- a/test/2.0/test-middleware-swagger-validator.js
+++ b/test/2.0/test-middleware-swagger-validator.js
@@ -35,6 +35,7 @@ var _ = require('lodash-compat');
 var assert = require('assert');
 var async = require('async');
 var helpers = require('../helpers');
+var customValidatorHelpers = require('../customValidatorHelpers.js');
 var request = require('supertest');
 var stream = require('stream');
 
@@ -50,245 +51,337 @@ var sampleInvalidPet = {
   name: 'Test Pet'
 };
 
-describe('Swagger Validator Middleware v2.0', function () {
-  describe('request validation', function () {
-    it('should not validate request when there are no operations', function (done) {
-      helpers.createServer([petStoreJson], {}, function (app) {
-        request(app)
-        .get('/api/foo')
-        .expect(200)
-        .end(helpers.expectContent('OK', done));
-      });
+/**
+ * Wrapper around helpers.createServer to apply a custom validator if one is
+ * supplied.
+ *
+ * @param {Object} [schemaValidator]  - a custom schema validator (or falsy to use the internal one)
+ * @param {any} initArgs  - the initialisation args
+ * @param {any} options   - the middleware options
+ * @param {any} callback  - the callback once the middleware is created
+ */
+function createServer(schemaValidator, initArgs, options, callback) {
+  if (schemaValidator) {
+    _.defaultsDeep(options, {
+      swaggerValidatorOptions: {
+        schemaValidator: schemaValidator
+      }
     });
+  }
+  helpers.createServer(initArgs, options, callback);
+}
 
-    it('should return an error for invalid request content type based on POST/PUT operation consumes', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].post.consumes = ['application/xml'];
-
-      helpers.createServer([swaggerObject], {}, function (app) {
-        request(app)
-          .post('/api/pets')
-          .send({
-            id: 1,
-            name: 'Fake Pet'
-          })
-          .expect(400)
-          .end(helpers.expectContent('Invalid content type (application/json).  These are valid: ' +
-                                       'application/xml', done));
-      });
-    });
-
-    it('should not return an error for invalid request content type for non-POST/PUT', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].get.consumes = ['application/xml'];
-
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            getAllPets: function (req, res) {
-              res.end('OK');
-            }
-          }
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets')
-          .expect(200)
-          .end(helpers.expectContent('OK', done));
-      });
-    });
-
-    it('should not return an error for valid request content type', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].post.consumes = ['application/xml', 'application/json'];
-
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            createPet: function (req, res) {
-              res.end('OK');
-            }
-          }
-        }
-      }, function (app) {
-        request(app)
-        .post('/api/pets')
-        .send({
-          id: 1,
-          name: 'Fake Pet'
-        })
-        .expect(200)
-        .end(helpers.expectContent('OK', done));
-      });
-    });
-
-    it('should not return an error for valid request content type with charset', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].post.consumes = ['application/xml', 'application/json'];
-
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            createPet: function (req, res) {
-              res.end('OK');
-            }
-          }
-        }
-      }, function (app) {
-        request(app)
-        .post('/api/pets')
-        .send({
-          id: 1,
-          name: 'Fake Pet'
-        })
-        .set('Content-Type', 'application/json; charset=utf-8')
-        .expect(200)
-        .end(helpers.expectContent('OK', done));
-      });
-    });
-
-    it('should return an error for missing required parameters', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].get.parameters[0].required = true;
-
-      helpers.createServer([swaggerObject], {}, function (app) {
-        request(app)
-          .get('/api/pets')
-          .expect(400)
-          .end(helpers.expectContent('Request validation failed: Parameter (status) is required', done));
-      });
-    });
-
-    it('should not return an error for missing required parameters with a default value', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].get.parameters[0].default = true;
-      swaggerObject.paths['/pets'].get.parameters[0].required = true;
-
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            getAllPets: function (req, res) {
-              res.end('OK');
-            }
-          }
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets')
-          .expect(200)
-          .end(helpers.expectContent('OK', done));
-      });
-    });
-
-    it('should not return an error for provided required parameters', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].get.parameters[0].required = true;
-
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            getAllPets: function (req, res) {
-              res.end('OK');
-            }
-          }
-        }
-      }, function (app) {
-        request(app)
-        .get('/api/pets')
-        .query({status: 'waiting'})
-        .expect(200)
-        .end(helpers.expectContent('OK', done));
-      });
-    });
-
-    it('should return an error for invalid parameter values based on type/format', function (done) {
-      var argName = 'arg0';
-      var badValue = 'fake';
-      var testScenarios = [
-        {in: 'query', name: argName, type: 'boolean'},
-        {in: 'query', name: argName, type: 'integer'},
-        {in: 'query', name: argName, type: 'number'},
-        {in: 'query', name: argName, type: 'string', format: 'date'},
-        {in: 'query', name: argName, type: 'string', format: 'date-time'},
-        {in: 'query', name: argName, type: 'array', items: {type: 'integer'}}
-      ];
-
-      async.map(testScenarios, function (scenario, callback) {
-        var cPetStore = _.cloneDeep(petStoreJson);
-        var cScenario = _.cloneDeep(scenario);
-        var content = {arg0: scenario.type === 'array' ? [1, 'fake'] : badValue};
-        var expectedMessage;
-
-        cPetStore.paths['/pets/{id}'].get.parameters = [cScenario];
-
-        if (scenario.type === 'array') {
-          expectedMessage = 'Parameter (' + argName + ') at index 1 is not a valid integer: fake';
-        } else {
-          expectedMessage = 'Parameter (' + scenario.name + ') is not a valid ' +
-                              (_.isUndefined(scenario.format) ?
-                                 '' :
-                                 scenario.format + ' ') + scenario.type + ': ' + badValue;
-        }
-
-        helpers.createServer([cPetStore], {}, function (app) {
+/**
+ * Function to run the tests, with the option to provide a schema validator or
+ * just use the one built in to the system if none is provided.
+ * This allows us to run the exact same tests with multiple validators, including
+ * the existing built-in one.
+ *
+ * @param {string} description    - additional description to identify the test suite
+ * @param {Object} [schemaValidator]  - optional custom validator to use
+ */
+function runTestsWithSchemaValidator(description, schemaValidator) {
+  describe('Swagger Validator Middleware v2.0 with ' + description, function () {
+    describe('request validation', function () {
+      it('should not validate request when there are no operations', function (done) {
+        createServer(schemaValidator, [petStoreJson], {}, function (app) {
           request(app)
-            .get('/api/pets/1')
-            .query(content)
-            .expect(400)
-            .end(function (err, res) {
-              if (err) {
-                return callback(err);
-              }
-              helpers.expectContent('Request validation failed: ' + expectedMessage)(undefined, res);
-              callback();
-            });
+            .get('/api/foo')
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
         });
-      }, function (err) {
-        if (err) {
-          return done(err);
-        }
-
-        done();
       });
-    });
 
-    it('should return an error for invalid parameter values based on type/format', function (done) {
-      var argName = 'arg0';
-      var testScenarios = [
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '0'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '12345'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '"2016-02-04T20:16:26+00:00"'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-99-04T20:16:26+00:00'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-99T20:16:26+00:00'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T99:16:26+00:00'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:99:26+00:00'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:99+00:00'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:26+99:00'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:26-99:00'},
-        {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:26-00:23'},
-      ];
+      it('should return an error for invalid request content type based on POST/PUT operation consumes', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
 
-      async.map(testScenarios, function (scenario, callback) {
-        var cPetStore = _.cloneDeep(petStoreJson);
-        var cScenario = _.cloneDeep(scenario.json);
-        var badValue = _.cloneDeep(scenario.value);
-        var content = {arg0: badValue};
-        var expectedMessage = 'Parameter (' + cScenario.name + ') is not a valid ' +
-                            (_.isUndefined(cScenario.format) ?
-                               '' :
-                               cScenario.format + ' ') + cScenario.type + ': ' + badValue;
+        swaggerObject.paths['/pets'].post.consumes = ['application/xml'];
 
-        cPetStore.paths['/pets/{id}'].get.parameters = [cScenario];
+        createServer(schemaValidator, [swaggerObject], {}, function (app) {
+          request(app)
+            .post('/api/pets')
+            .send({
+              id: 1,
+              name: 'Fake Pet'
+            })
+            .expect(400)
+            .end(helpers.expectContent('Invalid content type (application/json).  These are valid: ' +
+              'application/xml', done));
+        });
+      });
 
-        helpers.createServer([cPetStore],
-          {
+      it('should not return an error for invalid request content type for non-POST/PUT', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].get.consumes = ['application/xml'];
+
+        createServer(schemaValidator, [swaggerObject], {
+          swaggerRouterOptions: {
+            controllers: {
+              getAllPets: function (req, res) {
+                res.end('OK');
+              }
+            }
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets')
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
+      });
+
+      it('should not return an error for valid request content type', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].post.consumes = ['application/xml', 'application/json'];
+
+        createServer(schemaValidator, [swaggerObject], {
+          swaggerRouterOptions: {
+            controllers: {
+              createPet: function (req, res) {
+                res.end('OK');
+              }
+            }
+          }
+        }, function (app) {
+          request(app)
+            .post('/api/pets')
+            .send({
+              id: 1,
+              name: 'Fake Pet'
+            })
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
+      });
+
+      it('should not return an error for valid request content type with charset', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].post.consumes = ['application/xml', 'application/json'];
+
+        createServer(schemaValidator, [swaggerObject], {
+          swaggerRouterOptions: {
+            controllers: {
+              createPet: function (req, res) {
+                res.end('OK');
+              }
+            }
+          }
+        }, function (app) {
+          request(app)
+            .post('/api/pets')
+            .send({
+              id: 1,
+              name: 'Fake Pet'
+            })
+            .set('Content-Type', 'application/json; charset=utf-8')
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
+      });
+
+      it('should return an error for missing required parameters', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].get.parameters[0].required = true;
+
+        createServer(schemaValidator, [swaggerObject], {}, function (app) {
+          request(app)
+            .get('/api/pets')
+            .expect(400)
+            .end(helpers.expectContent('Request validation failed: Parameter (status) is required', done));
+        });
+      });
+
+      it('should not return an error for missing required parameters with a default value', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].get.parameters[0].default = true;
+        swaggerObject.paths['/pets'].get.parameters[0].required = true;
+
+        createServer(schemaValidator, [swaggerObject], {
+          swaggerRouterOptions: {
+            controllers: {
+              getAllPets: function (req, res) {
+                res.end('OK');
+              }
+            }
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets')
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
+      });
+
+      it('should not return an error for provided required parameters', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].get.parameters[0].required = true;
+
+        createServer(schemaValidator, [swaggerObject], {
+          swaggerRouterOptions: {
+            controllers: {
+              getAllPets: function (req, res) {
+                res.end('OK');
+              }
+            }
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets')
+            .query({status: 'waiting'})
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
+      });
+
+      it('should return an error for invalid parameter values based on type/format', function (done) {
+        var argName = 'arg0';
+        var badValue = 'fake';
+        var testScenarios = [
+          {in: 'query', name: argName, type: 'boolean'},
+          {in: 'query', name: argName, type: 'integer'},
+          {in: 'query', name: argName, type: 'number'},
+          {in: 'query', name: argName, type: 'string', format: 'date'},
+          {in: 'query', name: argName, type: 'string', format: 'date-time'},
+          {in: 'query', name: argName, type: 'array', items: {type: 'integer'}}
+        ];
+
+        async.map(testScenarios, function (scenario, callback) {
+          var cPetStore = _.cloneDeep(petStoreJson);
+          var cScenario = _.cloneDeep(scenario);
+          var content = {arg0: scenario.type === 'array' ? [1, 'fake'] : badValue};
+          var expectedMessage;
+
+          cPetStore.paths['/pets/{id}'].get.parameters = [cScenario];
+
+          if (scenario.type === 'array') {
+            expectedMessage = 'Parameter (' + argName + ') at index 1 is not a valid integer: fake';
+          } else {
+            expectedMessage = 'Parameter (' + scenario.name + ') is not a valid ' +
+              (_.isUndefined(scenario.format) ?
+                '' :
+                scenario.format + ' ') + scenario.type + ': ' + badValue;
+          }
+
+          createServer(schemaValidator, [cPetStore], {}, function (app) {
+            request(app)
+              .get('/api/pets/1')
+              .query(content)
+              .expect(400)
+              .end(function (err, res) {
+                if (err) {
+                  return callback(err);
+                }
+                helpers.expectContent('Request validation failed: ' + expectedMessage)(undefined, res);
+                callback();
+              });
+          });
+        }, function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          done();
+        });
+      });
+
+      it('should return an error for invalid parameter values based on type/format', function (done) {
+        var argName = 'arg0';
+        var testScenarios = [
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '0'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '12345'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '"2016-02-04T20:16:26+00:00"'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-99-04T20:16:26+00:00'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-99T20:16:26+00:00'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T99:16:26+00:00'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:99:26+00:00'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:99+00:00'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:26+99:00'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:26-99:00'},
+          {json: {in: 'query', name: argName, type: 'string', format: 'date-time'}, value: '2016-02-04T20:16:26-00:23'},
+        ];
+
+        async.map(testScenarios, function (scenario, callback) {
+          var cPetStore = _.cloneDeep(petStoreJson);
+          var cScenario = _.cloneDeep(scenario.json);
+          var badValue = _.cloneDeep(scenario.value);
+          var content = {arg0: badValue};
+          var expectedMessage = 'Parameter (' + cScenario.name + ') is not a valid ' +
+            (_.isUndefined(cScenario.format) ?
+              '' :
+              cScenario.format + ' ') + cScenario.type + ': ' + badValue;
+
+          cPetStore.paths['/pets/{id}'].get.parameters = [cScenario];
+
+          createServer(schemaValidator, [cPetStore],
+            {
+              swaggerRouterOptions: {
+                controllers: {
+                  getPetById: function (req, res) {
+                    res.end('OK');
+                  }
+                }
+              }
+            },
+            function (app) {
+              request(app)
+                .get('/api/pets/1')
+                .query(content)
+                .expect(400)
+                .end(function (err, res) {
+                  if (err) {
+                    return callback(err + '\n\tInvalid value that should have been rejected: ' + badValue);
+                  }
+                  helpers.expectContent('Request validation failed: ' + expectedMessage)(undefined, res);
+                  callback();
+                });
+            }
+          );
+        }, function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          done();
+        });
+      });
+
+      it('should not return an error for valid parameter values based on type/format', function (done) {
+        var argName = 'arg0';
+        var testScenarios = [
+          {in: 'query', name: argName, type: 'boolean'},
+          {in: 'query', name: argName, type: 'integer'},
+          {in: 'query', name: argName, type: 'number'},
+          {in: 'query', name: argName, type: 'string', format: 'date'},
+          {in: 'query', name: argName, type: 'string', format: 'date-time'},
+          {in: 'query', name: argName, type: 'string', format: 'date-time'},
+          {in: 'query', name: argName, type: 'string', format: 'date-time'},
+          {in: 'query', name: argName, type: 'array', items: {type: 'integer'}}
+        ];
+        var values = [
+          true,
+          1,
+          1.1,
+          '1981-03-12',
+          '1981-03-12T08:16:00-04:00',
+          '2016-09-22T23:19:08Z',
+          '2015-12-15T21:51:20.860Z',
+          [1, 2]
+        ];
+        var index = 0;
+
+        async.map(testScenarios, function (scenario, callback) {
+          var cPetStoreJson = _.cloneDeep(petStoreJson);
+          var cScenario = _.cloneDeep(scenario);
+
+          cPetStoreJson.paths['/pets/{id}'].get.parameters = [cScenario];
+
+          createServer(schemaValidator, [cPetStoreJson], {
             swaggerRouterOptions: {
               controllers: {
                 getPetById: function (req, res) {
@@ -296,1143 +389,1340 @@ describe('Swagger Validator Middleware v2.0', function () {
                 }
               }
             }
-          },
-          function (app) {
+          }, function (app) {
             request(app)
               .get('/api/pets/1')
-              .query(content)
-              .expect(400)
+              .query({arg0: values[index]})
+              .expect(200)
               .end(function (err, res) {
                 if (err) {
-                  return callback(err + '\n\tInvalid value that should have been rejected: ' + badValue);
+                  return callback(err);
                 }
-                helpers.expectContent('Request validation failed: ' + expectedMessage)(undefined, res);
+
+                helpers.expectContent('OK')(undefined, res);
+
                 callback();
               });
-            }
-          );
-      }, function (err) {
-        if (err) {
-          return done(err);
-        }
+          });
 
-        done();
-      });
-    });
-
-    it('should not return an error for valid parameter values based on type/format', function (done) {
-      var argName = 'arg0';
-      var testScenarios = [
-        {in: 'query', name: argName, type: 'boolean'},
-        {in: 'query', name: argName, type: 'integer'},
-        {in: 'query', name: argName, type: 'number'},
-        {in: 'query', name: argName, type: 'string', format: 'date'},
-        {in: 'query', name: argName, type: 'string', format: 'date-time'},
-        {in: 'query', name: argName, type: 'string', format: 'date-time'},
-        {in: 'query', name: argName, type: 'string', format: 'date-time'},
-        {in: 'query', name: argName, type: 'array', items: {type: 'integer'}}
-      ];
-      var values = [
-        true,
-        1,
-        1.1,
-        '1981-03-12',
-        '1981-03-12T08:16:00-04:00',
-        '2016-09-22T23:19:08Z',
-        '2015-12-15T21:51:20.860Z',
-        [1, 2]
-      ];
-      var index = 0;
-
-      async.map(testScenarios, function (scenario, callback) {
-        var cPetStoreJson = _.cloneDeep(petStoreJson);
-        var cScenario = _.cloneDeep(scenario);
-
-        cPetStoreJson.paths['/pets/{id}'].get.parameters = [cScenario];
-
-        helpers.createServer([cPetStoreJson], {
-          swaggerRouterOptions: {
-            controllers: {
-              getPetById: function (req, res) {
-                res.end('OK');
-              }
-            }
+          index++;
+        }, function (err) {
+          if (err) {
+            return done(err);
           }
-        }, function (app) {
-          request(app)
-            .get('/api/pets/1')
-            .query({arg0: values[index]})
-            .expect(200)
-            .end(function (err, res) {
-              if (err) {
-                return callback(err);
-              }
 
-              helpers.expectContent('OK')(undefined, res);
-
-              callback();
-            });
+          done();
         });
-
-        index++;
-      }, function (err) {
-        if (err) {
-          return done(err);
-        }
-
-        done();
       });
-    });
 
-    it('should return an error for invalid parameter values not based on type/format', function (done) {
-      var argName = 'arg0';
-      var testScenarios = [
-        {name: argName, in: 'query', enum: ['1', '2', '3'], type: 'string'},
-        {name: argName, in: 'query', maximum: 1, type: 'integer'},
-        {name: argName, in: 'query', maximum: 1, exclusiveMaximum: true, type: 'integer'},
-        {name: argName, in: 'query', maxItems: 1, type: 'array', items: {type: 'string'}},
-        {name: argName, in: 'query', maxLength: 1, type: 'string'},
-        {name: argName, in: 'query', minimum: 1, type: 'integer'},
-        {name: argName, in: 'query', minimum: 1, exclusiveMinimum: true, type: 'integer'},
-        {name: argName, in: 'query', minItems: 2, type: 'array', items: {type: 'string'}},
-        {name: argName, in: 'query', minLength: 2, type: 'string'},
-        {name: argName, in: 'query', multipleOf: 3, type: 'integer'},
-        {name: argName, in: 'query', pattern: '[bc]+', type: 'string'},
-        {name: argName, in: 'query', type: 'array', items: {type: 'string'}, uniqueItems: true}
-      ];
-      var values = [
-        'fake',
-        2,
-        1,
-        ['1', '2'],
-        'fake',
-        0,
-        1,
-        ['1'],
-        'f',
-        5,
-        'fake',
-        ['fake', 'fake']
-      ];
-      var errors = [
-        'Parameter (' + argName + ') is not an allowable value (1, 2, 3): fake',
-        'Parameter (' + argName + ') is greater than the configured maximum (1): 2',
-        'Parameter (' + argName + ') is greater than or equal to the configured maximum (1): 1',
-        'Parameter (' + argName + ') is too long (2), maximum 1',
-        'Parameter (' + argName + ') is too long (4 chars), maximum 1',
-        'Parameter (' + argName + ') is less than the configured minimum (1): 0',
-        'Parameter (' + argName + ') is less than or equal to the configured minimum (1): 1',
-        'Parameter (' + argName + ') is too short (1), minimum 2',
-        'Parameter (' + argName + ') is too short (1 chars), minimum 2',
-        'Parameter (' + argName + ') is not a multiple of 3',
-        'Parameter (' + argName + ') does not match required pattern: [bc]+',
-        'Parameter (' + argName + ') does not allow duplicate values: fake, fake'
-      ];
-      var index = 0;
+      it('should return an error for invalid parameter values not based on type/format', function (done) {
+        var argName = 'arg0';
+        var testScenarios = [
+          {name: argName, in: 'query', enum: ['1', '2', '3'], type: 'string'},
+          {name: argName, in: 'query', maximum: 1, type: 'integer'},
+          {name: argName, in: 'query', maximum: 1, exclusiveMaximum: true, type: 'integer'},
+          {name: argName, in: 'query', maxItems: 1, type: 'array', items: {type: 'string'}},
+          {name: argName, in: 'query', maxLength: 1, type: 'string'},
+          {name: argName, in: 'query', minimum: 1, type: 'integer'},
+          {name: argName, in: 'query', minimum: 1, exclusiveMinimum: true, type: 'integer'},
+          {name: argName, in: 'query', minItems: 2, type: 'array', items: {type: 'string'}},
+          {name: argName, in: 'query', minLength: 2, type: 'string'},
+          {name: argName, in: 'query', multipleOf: 3, type: 'integer'},
+          {name: argName, in: 'query', pattern: '[bc]+', type: 'string'},
+          {name: argName, in: 'query', type: 'array', items: {type: 'string'}, uniqueItems: true}
+        ];
+        var values = [
+          'fake',
+          2,
+          1,
+          ['1', '2'],
+          'fake',
+          0,
+          1,
+          ['1'],
+          'f',
+          5,
+          'fake',
+          ['fake', 'fake']
+        ];
+        var errors = [
+          'Parameter (' + argName + ') is not an allowable value (1, 2, 3): fake',
+          'Parameter (' + argName + ') is greater than the configured maximum (1): 2',
+          'Parameter (' + argName + ') is greater than or equal to the configured maximum (1): 1',
+          'Parameter (' + argName + ') is too long (2), maximum 1',
+          'Parameter (' + argName + ') is too long (4 chars), maximum 1',
+          'Parameter (' + argName + ') is less than the configured minimum (1): 0',
+          'Parameter (' + argName + ') is less than or equal to the configured minimum (1): 1',
+          'Parameter (' + argName + ') is too short (1), minimum 2',
+          'Parameter (' + argName + ') is too short (1 chars), minimum 2',
+          'Parameter (' + argName + ') is not a multiple of 3',
+          'Parameter (' + argName + ') does not match required pattern: [bc]+',
+          'Parameter (' + argName + ') does not allow duplicate values: fake, fake'
+        ];
+        var index = 0;
 
-      async.map(testScenarios, function (scenario, callback) {
-        var cPetStoreJson = _.cloneDeep(petStoreJson);
-        var expectedMessage = errors[index];
-        var testValue = values[index];
+        async.map(testScenarios, function (scenario, callback) {
+          var cPetStoreJson = _.cloneDeep(petStoreJson);
+          var expectedMessage = errors[index];
+          var testValue = values[index];
 
-        cPetStoreJson.paths['/pets/{id}'].get.parameters = [scenario];
+          cPetStoreJson.paths['/pets/{id}'].get.parameters = [scenario];
 
-        helpers.createServer([cPetStoreJson], {}, function (app) {
+          createServer(schemaValidator, [cPetStoreJson], {}, function (app) {
+            request(app)
+              .get('/api/pets/1')
+              .query({
+                arg0: testValue
+              })
+              .expect(400)
+              .end(function (err, res) {
+                if (res) {
+                  res.expectedMessage = 'Request validation failed: ' + expectedMessage;
+                }
+
+                callback(err, res);
+              });
+          });
+
+          index++;
+        }, function (err, responses) {
+          if (err) {
+            return done(err);
+          }
+
+          _.each(responses, function (res) {
+            helpers.expectContent(res.expectedMessage)(undefined, res);
+          });
+
+          done();
+        });
+      });
+
+      it('should not return an error for valid parameter values not based on type/format', function (done) {
+        var argName = 'arg0';
+        var testScenarios = [
+          {name: argName, in: 'query', enum: ['1', '2', '3'], type: 'string'},
+          {name: argName, in: 'query', maximum: 1, type: 'integer'},
+          {name: argName, in: 'query', maximum: 1, exclusiveMaximum: true, type: 'integer'},
+          {name: argName, in: 'query', maxItems: 1, type: 'array', items: {type: 'string'}},
+          {name: argName, in: 'query', maxLength: 5, type: 'string'},
+          {name: argName, in: 'query', minimum: 1, type: 'integer'},
+          {name: argName, in: 'query', minimum: 0, exclusiveMinimum: true, type: 'integer'},
+          {name: argName, in: 'query', minItems: 2, type: 'array', items: {type: 'string'}},
+          {name: argName, in: 'query', minLength: 2, type: 'string'},
+          {name: argName, in: 'query', multipleOf: 3, type: 'integer'},
+          {name: argName, in: 'query', pattern: '[abc]+', type: 'string'},
+          {name: argName, in: 'query', type: 'array', items: {type: 'string'}, uniqueItems: true}
+        ];
+        var values = [
+          '2',
+          1,
+          0,
+          ['1'],
+          'fake',
+          1,
+          1,
+          ['1', '2'],
+          'fake',
+          9,
+          'fake',
+          ['fake', 'faker']
+        ];
+        var index = 0;
+
+        async.map(testScenarios, function (scenario, callback) {
+          var cPetStoreJson = _.cloneDeep(petStoreJson);
+          var testValue = values[index];
+
+          cPetStoreJson.paths['/pets/{id}'].get.parameters = [scenario];
+
+          createServer(schemaValidator, [cPetStoreJson], {
+            swaggerRouterOptions: {
+              controllers: {
+                getPetById: function (req, res) {
+                  res.end('OK');
+                }
+              }
+            }
+          }, function (app) {
+            request(app)
+              .get('/api/pets/1')
+              .query({
+                arg0: testValue
+              })
+              .expect(200)
+              .end(helpers.expectContent('OK', callback));
+          });
+
+          index++;
+        }, function (err) {
+          if (err) {
+            return done(err);
+          }
+
+          done();
+        });
+      });
+
+      it('should return an error for an invalid model parameter', function (done) {
+        createServer(schemaValidator, [petStoreJson], {}, function (app) {
           request(app)
-            .get('/api/pets/1')
-            .query({
-              arg0: testValue
-            })
+            .post('/api/pets')
+            .send({})
             .expect(400)
-            .end(function (err, res) {
-              if (res) {
-                res.expectedMessage = 'Request validation failed: ' + expectedMessage;
-              }
-
-              callback(err, res);
-            });
+            .end(helpers.expectContent('Request validation failed: Parameter (pet) failed schema validation', done));
         });
-
-        index++;
-      }, function (err, responses) {
-        if (err) {
-          return done(err);
-        }
-
-        _.each(responses, function (res) {
-          helpers.expectContent(res.expectedMessage)(undefined, res);
-        });
-
-        done();
       });
-    });
 
-    it('should not return an error for valid parameter values not based on type/format', function (done) {
-      var argName = 'arg0';
-      var testScenarios = [
-        {name: argName, in: 'query', enum: ['1', '2', '3'], type: 'string'},
-        {name: argName, in: 'query', maximum: 1, type: 'integer'},
-        {name: argName, in: 'query', maximum: 1, exclusiveMaximum: true, type: 'integer'},
-        {name: argName, in: 'query', maxItems: 1, type: 'array', items: {type: 'string'}},
-        {name: argName, in: 'query', maxLength: 5, type: 'string'},
-        {name: argName, in: 'query', minimum: 1, type: 'integer'},
-        {name: argName, in: 'query', minimum: 0, exclusiveMinimum: true, type: 'integer'},
-        {name: argName, in: 'query', minItems: 2, type: 'array', items: {type: 'string'}},
-        {name: argName, in: 'query', minLength: 2, type: 'string'},
-        {name: argName, in: 'query', multipleOf: 3, type: 'integer'},
-        {name: argName, in: 'query', pattern: '[abc]+', type: 'string'},
-        {name: argName, in: 'query', type: 'array', items: {type: 'string'}, uniqueItems: true}
-      ];
-      var values = [
-        '2',
-        1,
-        0,
-        ['1'],
-        'fake',
-        1,
-        1,
-        ['1', '2'],
-        'fake',
-        9,
-        'fake',
-        ['fake', 'faker']
-      ];
-      var index = 0;
-
-      async.map(testScenarios, function (scenario, callback) {
-        var cPetStoreJson = _.cloneDeep(petStoreJson);
-        var testValue = values[index];
-
-        cPetStoreJson.paths['/pets/{id}'].get.parameters = [scenario];
-
-        helpers.createServer([cPetStoreJson], {
+      it('should not return an error for a valid model parameter', function (done) {
+        createServer(schemaValidator, [petStoreJson], {
           swaggerRouterOptions: {
             controllers: {
-              getPetById: function (req, res) {
+              createPet: function (req, res) {
                 res.end('OK');
               }
             }
           }
         }, function (app) {
           request(app)
-          .get('/api/pets/1')
-          .query({
-            arg0: testValue
-          })
-          .expect(200)
-          .end(helpers.expectContent('OK', callback));
+            .post('/api/pets')
+            .send({
+              id: 1,
+              name: 'Fake Pet'
+            })
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
         });
-
-        index++;
-      }, function (err) {
-        if (err) {
-          return done(err);
-        }
-
-        done();
       });
     });
 
-    it('should return an error for an invalid model parameter', function (done) {
-      helpers.createServer([petStoreJson], {}, function (app) {
-        request(app)
-          .post('/api/pets')
-          .send({})
-          .expect(400)
-          .end(helpers.expectContent('Request validation failed: Parameter (pet) failed schema validation', done));
-      });
-    });
-
-    it('should not return an error for a valid model parameter', function (done) {
-      helpers.createServer([petStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            createPet: function (req, res) {
-              res.end('OK');
-            }
+    describe('response validation', function () {
+      it('should not validate response when there are no operations', function (done) {
+        createServer(schemaValidator, [petStoreJson], {
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        }
-      }, function (app) {
-        request(app)
-          .post('/api/pets')
-          .send({
-            id: 1,
-            name: 'Fake Pet'
-          })
-          .expect(200)
-          .end(helpers.expectContent('OK', done));
+        }, function (app) {
+          request(app)
+            .get('/api/foo')
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
       });
-    });
-  });
 
-  describe('response validation', function () {
-    it('should not validate response when there are no operations', function (done) {
-      helpers.createServer([petStoreJson], {
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/foo')
-          .expect(200)
-          .end(helpers.expectContent('OK', done));
-      });
-    });
+      it('should not validate response when options.validateResponse is false', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-    it('should not validate response when options.validateResponse is false', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              res.end('OK');
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: false
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(200)
-          .end(helpers.expectContent('OK', done));
-      });
-    });
-
-    it('should return an error for invalid response content type', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              res.setHeader('Content-Type', 'application/x-yaml');
-              res.end(samplePet);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: invalid content type (application/x-yaml).  These ' +
-                                       'are valid: application/json, application/xml, text/plain, text/html', done));
-      });
-    });
-
-    it('should not return an error for valid response content type', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              res.setHeader('Content-Type', 'application/json');
-              res.end(samplePet);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(200)
-          .end(helpers.expectContent(samplePet, done));
-      });
-    });
-
-    it('should return an error for model type not parsable', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              res.end('OK');
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: value expected to be an array/object but is not',
-                                     done));
-      });
-    });
-
-    it('should return an error for an invalid response primitive (void)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      delete cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema;
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              return res.end(samplePet);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: void does not allow a value', done));
-      });
-    });
-
-    it('should return an error for an invalid response primitive (non-void)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      cPetStoreJson.paths['/pets/categories/count'] = {
-        get: {
-          'x-swagger-router-controller': 'Pets',
-          operationId: 'getCategoryCount',
-          responses: {
-            '200': {
-              description: 'Valid response',
-              schema: {
-                type: 'integer'
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                res.end('OK');
               }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: false
           }
-        }
-      };
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getCategoryCount': function (req, res) {
-              return res.end('Some value');
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/categories/count')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: not a valid integer: Some value', done));
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
       });
-    });
 
-    it('should not return an error for an valid response primitive (non-void)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should return an error for invalid response content type', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      cPetStoreJson.paths['/pets/categories/count'] = {
-        get: {
-          'x-swagger-router-controller': 'Pets',
-          operationId: 'getCategoryCount',
-          responses: {
-            '200': {
-              description: 'Valid response',
-              schema: {
-                type: 'string'
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                res.setHeader('Content-Type', 'application/x-yaml');
+                res.end(samplePet);
               }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        }
-      };
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getCategoryCount': function (req, res) {
-              return res.end('swagger-tools');
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/categories/count')
-          .expect(200)
-          .end(helpers.expectContent('swagger-tools', done));
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: invalid content type (application/x-yaml).  These ' +
+              'are valid: application/json, application/xml, text/plain, text/html', done));
+        });
       });
-    });
 
-    it('should return an error for an invalid response primitive (non-void)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should not return an error for valid response content type', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      cPetStoreJson.paths['/pets/categories/count'] = {
-        get: {
-          'x-swagger-router-controller': 'Pets',
-          operationId: 'getCategoryCount',
-          responses: {
-            '200': {
-              description: 'Valid response',
-              schema: {
-                type: 'array',
-                items: {
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                res.setHeader('Content-Type', 'application/json');
+                res.end(samplePet);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(200)
+            .end(helpers.expectContent(samplePet, done));
+        });
+      });
+
+      it('should return an error for model type not parsable', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                res.end('OK');
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: value expected to be an array/object but is not',
+              done));
+        });
+      });
+
+      it('should return an error for an invalid response primitive (void)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+        delete cPetStoreJson.paths['/pets/{id}'].get.responses['200'].schema;
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                return res.end(samplePet);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: void does not allow a value', done));
+        });
+      });
+
+      it('should return an error for an invalid response primitive (non-void)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+        cPetStoreJson.paths['/pets/categories/count'] = {
+          get: {
+            'x-swagger-router-controller': 'Pets',
+            operationId: 'getCategoryCount',
+            responses: {
+              '200': {
+                description: 'Valid response',
+                schema: {
                   type: 'integer'
                 }
               }
             }
           }
-        }
-      };
+        };
 
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getCategoryCount': function (req, res) {
-              return res.end([1, 'Some value', 3]);
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getCategoryCount': function (req, res) {
+                return res.end('Some value');
+              }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/categories/count')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: value at index 1 is not a valid integer: Some value',
-                                     done));
+        }, function (app) {
+          request(app)
+            .get('/api/pets/categories/count')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: not a valid integer: Some value', done));
+        });
       });
-    });
 
-    it('should not return an error for an valid response primitive (non-void)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should not return an error for an valid response primitive (non-void)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      cPetStoreJson.paths['/pets/categories/count'] = {
-        get: {
-          'x-swagger-router-controller': 'Pets',
-          operationId: 'getCategoryCount',
-          responses: {
-            '200': {
-              description: 'Valid response',
-              schema: {
-                type: 'array',
-                items: {
-                  type: 'integer'
+        cPetStoreJson.paths['/pets/categories/count'] = {
+          get: {
+            'x-swagger-router-controller': 'Pets',
+            operationId: 'getCategoryCount',
+            responses: {
+              '200': {
+                description: 'Valid response',
+                schema: {
+                  type: 'string'
                 }
               }
             }
           }
-        }
-      };
+        };
 
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getCategoryCount': function (req, res) {
-              return res.end([1, 2, 3]);
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getCategoryCount': function (req, res) {
+                return res.end('swagger-tools');
+              }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/categories/count')
-          .expect(200)
-          .end(helpers.expectContent([1, 2, 3],done));
+        }, function (app) {
+          request(app)
+            .get('/api/pets/categories/count')
+            .expect(200)
+            .end(helpers.expectContent('swagger-tools', done));
+        });
       });
-    });
 
-    it('should return an error for an invalid response model (simple)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should return an error for an invalid response primitive (non-void)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              return res.end({});
+        cPetStoreJson.paths['/pets/categories/count'] = {
+          get: {
+            'x-swagger-router-controller': 'Pets',
+            operationId: 'getCategoryCount',
+            responses: {
+              '200': {
+                description: 'Valid response',
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'integer'
+                  }
+                }
+              }
             }
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: failed schema validation', done));
+        };
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getCategoryCount': function (req, res) {
+                return res.end([1, 'Some value', 3]);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/categories/count')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: value at index 1 is not a valid integer: Some value',
+              done));
+        });
       });
-    });
 
-    it('should not return an error for an valid response model (simple)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should not return an error for an valid response primitive (non-void)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              return res.end(samplePet);
+        cPetStoreJson.paths['/pets/categories/count'] = {
+          get: {
+            'x-swagger-router-controller': 'Pets',
+            operationId: 'getCategoryCount',
+            responses: {
+              '200': {
+                description: 'Valid response',
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'integer'
+                  }
+                }
+              }
             }
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(200)
-          .end(helpers.expectContent(samplePet, done));
+        };
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getCategoryCount': function (req, res) {
+                return res.end([1, 2, 3]);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/categories/count')
+            .expect(200)
+            .end(helpers.expectContent([1, 2, 3],done));
+        });
       });
-    });
 
-    it('should return an error for an invalid response model (complex)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-      var cSamplePet = _.cloneDeep(samplePet);
+      it('should return an error for an invalid response model (simple)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      // Make name required
-      cPetStoreJson.definitions.Tag.required = ['name'];
-
-      cSamplePet.tags = [
-        {id: 1, name: 'Tag 1'},
-        {id: 2},
-        {id: 3, name: 'Tag 3'},
-      ];
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              return res.end(cSamplePet);
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                return res.end({});
+              }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: failed schema validation', done));
-      });
-    });
-
-    it('should not return an error for a valid response model (complex)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-      var cSamplePet = _.cloneDeep(samplePet);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      cSamplePet.tags = [
-        {id: 1, name: 'Tag 1'},
-        {id: 2},
-        {id: 3, name: 'Tag 3'},
-      ];
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              return res.end(cSamplePet);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(200)
-          .end(helpers.expectContent(cSamplePet, done));
-      });
-    });
-
-    it('should return an error for an invalid response array of models (simple)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPets': function (req, res) {
-              return res.end([
-                samplePet,
-                {},
-                samplePet
-              ]);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets')
-            .query({status: 'available'})
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
             .expect(500)
             .end(helpers.expectContent('Response validation failed: failed schema validation', done));
+        });
       });
-    });
 
-    it('should not return an error for a valid response array of models (simple)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should not return an error for an valid response model (simple)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPets': function (req, res) {
-              return res.end([
-                samplePet,
-                samplePet,
-                samplePet
-              ]);
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                return res.end(samplePet);
+              }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets')
-          .query({status: 'available'})
-          .expect(200)
-          .end(helpers.expectContent([samplePet, samplePet, samplePet], done));
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(200)
+            .end(helpers.expectContent(samplePet, done));
+        });
       });
-    });
 
-    it('should return an error for an invalid response array of models (complex)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-      var cSamplePet = _.cloneDeep(samplePet);
+      it('should return an error for an invalid response model (complex)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+        var cSamplePet = _.cloneDeep(samplePet);
 
-      cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      // Make name required
-      cPetStoreJson.definitions.Tag.required = ['name'];
+        // Make name required
+        cPetStoreJson.definitions.Tag.required = ['name'];
 
-      cSamplePet.tags = [
+        cSamplePet.tags = [
+          {id: 1, name: 'Tag 1'},
+          {id: 2},
+          {id: 3, name: 'Tag 3'},
+        ];
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                return res.end(cSamplePet);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: failed schema validation', done));
+        });
+      });
+
+      it('should not return an error for a valid response model (complex)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+        var cSamplePet = _.cloneDeep(samplePet);
+
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+        cSamplePet.tags = [
         {id: 1, name: 'Tag 1'},
         {id: 2},
         {id: 3, name: 'Tag 3'},
-      ];
+        ];
 
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPets': function (req, res) {
-              return res.end([
-                cSamplePet,
-                {},
-                cSamplePet
-              ]);
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                return res.end(cSamplePet);
+              }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets')
-          .query({status: 'available'})
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: failed schema validation', done));
-      });
-    });
-
-    it('should not return an error for a valid response array of models (complex)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-      var cSamplePet = _.cloneDeep(samplePet);
-
-      cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
-
-      cSamplePet.tags = [
-        {id: 1, name: 'Tag 1'},
-        {id: 2},
-        {id: 3, name: 'Tag 3'},
-      ];
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPets': function (req, res) {
-              return res.end([
-                cSamplePet,
-                cSamplePet,
-                cSamplePet
-              ]);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets')
-          .query({status: 'available'})
-          .expect(200)
-          .end(helpers.expectContent([
-            cSamplePet,
-            cSamplePet,
-            cSamplePet
-          ], done));
-      });
-    });
-
-
-
-    it('should validate a valid piped response', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              var s = new stream.Readable();
-              s.push(new Buffer(JSON.stringify(samplePet)));
-              s.push(null);
-              s.pipe(res);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(200)
-          .end(helpers.expectContent(samplePet, done));
-      });
-    });
-
-    it('should validate an invalid piped response', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              var s = new stream.Readable();
-              s.push(new Buffer(JSON.stringify(sampleInvalidPet)));
-              s.push(null);
-              s.pipe(res);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: failed schema validation', done));
-      });
-    });
-  });
-
-  describe('issues', function () {
-    it('should include original response in response validation errors (Issue 82)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              res.setHeader('Content-Type', 'application/x-yaml');
-              res.end(samplePet);
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        app.use(function (err, req, res, next) {
-          assert.deepEqual(err.originalResponse, samplePet);
-
-          next();
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(200)
+            .end(helpers.expectContent(cSamplePet, done));
         });
-
-        request(app)
-          .get('/api/pets/1')
-          .expect(500)
-          .end(helpers.expectContent('Response validation failed: invalid content type (application/x-yaml).  These ' +
-                                       'are valid: application/json, application/xml, text/plain, text/html', done));
       });
-    });
 
-    it('should not throw an error for responses that use the default response (Issue 99)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should return an error for an invalid response array of models (simple)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
-      cPetStoreJson.paths['/pets/{id}'].get.responses.default = cPetStoreJson.paths['/pets/{id}'].get.responses['200'];
+        cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
 
-      delete cPetStoreJson.paths['/pets/{id}'].get.responses['200'];
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              res.end(samplePet);
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPets': function (req, res) {
+                return res.end([
+                  samplePet,
+                  {},
+                  samplePet
+                ]);
+              }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        app.use(function (err, req, res, next) {
-          assert.deepEqual(err.originalResponse, samplePet);
-
-          next();
+        }, function (app) {
+          request(app)
+            .get('/api/pets')
+            .query({status: 'available' })
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: failed schema validation', done));
         });
+      });
 
-        request(app)
-          .get('/api/pets/1')
-          .expect(200)
-          .end(helpers.expectContent(samplePet, done));
+      it('should not return an error for a valid response array of models (simple)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPets': function (req, res) {
+                return res.end([
+                  samplePet,
+                  samplePet,
+                  samplePet
+                ]);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets')
+            .query({status: 'available' })
+            .expect(200)
+            .end(helpers.expectContent([samplePet, samplePet, samplePet], done));
+        });
+      });
+
+      it('should return an error for an invalid response array of models (complex)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+        var cSamplePet = _.cloneDeep(samplePet);
+
+        cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
+
+        // Make name required
+        cPetStoreJson.definitions.Tag.required = ['name'];
+
+        cSamplePet.tags = [
+          {id: 1, name: 'Tag 1'},
+          {id: 2},
+          {id: 3, name: 'Tag 3'},
+        ];
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPets': function (req, res) {
+                return res.end([
+                  cSamplePet,
+                  {},
+                  cSamplePet
+                ]);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets')
+            .query({status: 'available' })
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: failed schema validation', done));
+        });
+      });
+
+      it('should not return an error for a valid response array of models (complex)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+        var cSamplePet = _.cloneDeep(samplePet);
+
+        cPetStoreJson.paths['/pets'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets'].get.operationId = 'getPets';
+
+        cSamplePet.tags = [
+          {id: 1, name: 'Tag 1'},
+          {id: 2},
+          {id: 3, name: 'Tag 3'},
+        ];
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPets': function (req, res) {
+                return res.end([
+                  cSamplePet,
+                  cSamplePet,
+                  cSamplePet
+                ]);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets')
+            .query({status: 'available'})
+            .expect(200)
+            .end(helpers.expectContent([
+              cSamplePet,
+              cSamplePet,
+              cSamplePet
+            ], done));
+        });
+      });
+
+
+
+      it('should validate a valid piped response', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                var s = new stream.Readable();
+                s.push(new Buffer(JSON.stringify(samplePet)));
+                s.push(null);
+                s.pipe(res);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(200)
+            .end(helpers.expectContent(samplePet, done));
+        });
+      });
+
+      it('should validate an invalid piped response', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                var s = new stream.Readable();
+                s.push(new Buffer(JSON.stringify(sampleInvalidPet)));
+                s.push(null);
+                s.pipe(res);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: failed schema validation', done));
+        });
       });
     });
 
-    it('should not throw an error for requests using non-string collectionFormats (Issue 242)', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-      var expectedValue = [1, 2, 3];
+    describe('issues', function () {
+      it('should include original response in response validation errors (Issue 82)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      swaggerObject.paths['/pets'].get.parameters.push({
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                res.setHeader('Content-Type', 'application/x-yaml');
+                res.end(samplePet);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          app.use(function (err, req, res, next) {
+            assert.deepEqual(err.originalResponse, samplePet);
+
+            next();
+          });
+
+          request(app)
+            .get('/api/pets/1')
+            .expect(500)
+            .end(helpers.expectContent('Response validation failed: invalid content type (application/x-yaml).  These ' +
+              'are valid: application/json, application/xml, text/plain, text/html', done));
+        });
+      });
+
+      it('should not throw an error for responses that use the default response (Issue 99)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get.responses.default = cPetStoreJson.paths['/pets/{id}'].get.responses['200'];
+
+        delete cPetStoreJson.paths['/pets/{id}'].get.responses['200'];
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                res.end(samplePet);
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          app.use(function (err, req, res, next) {
+            assert.deepEqual(err.originalResponse, samplePet);
+
+            next();
+          });
+
+          request(app)
+            .get('/api/pets/1')
+            .expect(200)
+            .end(helpers.expectContent(samplePet, done));
+        });
+      });
+
+      it('should not throw an error for requests using non-string collectionFormats (Issue 242)', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+        var expectedValue = [1, 2, 3];
+
+        swaggerObject.paths['/pets'].get.parameters.push({
           in: 'query',
-        name: 'myArr',
-        description: 'Simple array value',
-        required: true,
-        type: 'array',
-        items: {
-          type: 'string'
-        },
-        collectionFormat: 'pipes'
-      });
+          name: 'myArr',
+          description: 'Simple array value',
+          required: true,
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          collectionFormat: 'pipes'
+        });
 
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            getAllPets: function (req, res) {
-              assert.deepEqual(expectedValue, req.swagger.params.myArr.value);
+        createServer(schemaValidator, [swaggerObject], {
+          swaggerRouterOptions: {
+            controllers: {
+              getAllPets: function (req, res) {
+                assert.deepEqual(expectedValue, req.swagger.params.myArr.value);
 
-              res.end('OK');
+                res.end('OK');
+              }
             }
           }
-        }
       }, function(app) {
-        request(app)
-          .get('/api/pets')
+          request(app)
+            .get('/api/pets')
           .query({myArr: expectedValue.join('|')})
-          .expect(200)
-          .end(helpers.expectContent('OK', done));
+            .expect(200)
+            .end(helpers.expectContent('OK', done));
+        });
       });
-    });
 
-    it('should not validate response when there is no schema for the response code (Issue 232)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should not validate response when there is no schema for the response code (Issue 232)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
 
-      delete cPetStoreJson.paths['/pets/{id}'].get.responses.default;
+        delete cPetStoreJson.paths['/pets/{id}'].get.responses.default;
 
-      cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
-      cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
+        cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'] = 'Pets';
+        cPetStoreJson.paths['/pets/{id}'].get.operationId = 'getPetById';
 
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getPetById': function (req, res) {
-              res.statusCode = 304;
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getPetById': function (req, res) {
+                res.statusCode = 304;
 
-              res.end();
+                res.end();
+              }
             }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .expect(304)
-          .end(done);
+        }, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .expect(304)
+            .end(done);
+        });
       });
-    });
 
-    it('should return an error for decimal "integers" (Issue 279)', function (done) {
-      var cPetStore = _.cloneDeep(petStoreJson);
-      var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: 1.1';
-
-      cPetStore.paths['/pets/{id}'].get.parameters = [{
-        in: 'query',
-        name: 'arg0',
-        type: 'integer'
-      }];
-
-      helpers.createServer([cPetStore], {}, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .query({
-            arg0: 1.1
-          })
-          .expect(400)
-          .end(helpers.expectContent(expectedMessage, done));
-      });
-    });
-
-    it('should return an error for number+string "numbers" (Issue 279)', function (done) {
-      var cPetStore = _.cloneDeep(petStoreJson);
-      var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid number: 2something';
-
-      cPetStore.paths['/pets/{id}'].get.parameters = [{
-        in: 'query',
-        name: 'arg0',
-        type: 'number'
-      }];
-
-      helpers.createServer([cPetStore], {}, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .query({
-            arg0: '2something'
-          })
-          .expect(400)
-          .end(helpers.expectContent(expectedMessage, done));
-      });
-    });
-
-    it('should return an error for number+string "integers" (Issue 279)', function (done) {
-      var cPetStore = _.cloneDeep(petStoreJson);
-      var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: 2something';
-
-      cPetStore.paths['/pets/{id}'].get.parameters = [{
-        in: 'query',
-        name: 'arg0',
-        type: 'integer'
-      }];
-
-      helpers.createServer([cPetStore], {}, function (app) {
-        request(app)
-          .get('/api/pets/1')
-          .query({
-            arg0: '2something'
-          })
-          .expect(400)
-          .end(helpers.expectContent(expectedMessage, done));
-      });
-    });
-
-    describe('should handle allowEmptyValue (Issue 282)', function () {
-      it('allowEmptyValue false', function (done) {
+      it('should return an error for decimal "integers" (Issue 279)', function (done) {
         var cPetStore = _.cloneDeep(petStoreJson);
-        var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: ';
+        var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: 1.1';
 
         cPetStore.paths['/pets/{id}'].get.parameters = [{
-            in: 'query',
+          in: 'query',
           name: 'arg0',
           type: 'integer'
         }];
 
-        helpers.createServer([cPetStore], {
-          swaggerRouterOptions: {
-            controllers: {
-              getPetById: function (req, res) {
-                res.end('OK');
-              }
-            }
-          }
-        }, function (app) {
+        createServer(schemaValidator, [cPetStore], {}, function (app) {
           request(app)
             .get('/api/pets/1')
             .query({
-              arg0: ''
+              arg0: 1.1
             })
             .expect(400)
             .end(helpers.expectContent(expectedMessage, done));
         });
       });
 
-      it('allowEmptyValue true', function (done) {
+      it('should return an error for number+string "numbers" (Issue 279)', function (done) {
         var cPetStore = _.cloneDeep(petStoreJson);
+        var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid number: 2something';
 
         cPetStore.paths['/pets/{id}'].get.parameters = [{
-            in: 'query',
+          in: 'query',
           name: 'arg0',
-          type: 'integer',
-          allowEmptyValue: true
+          type: 'number'
         }];
 
-        helpers.createServer([cPetStore], {
+        createServer(schemaValidator, [cPetStore], {}, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .query({
+              arg0: '2something'
+            })
+            .expect(400)
+            .end(helpers.expectContent(expectedMessage, done));
+        });
+      });
+
+      it('should return an error for number+string "integers" (Issue 279)', function (done) {
+        var cPetStore = _.cloneDeep(petStoreJson);
+        var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: 2something';
+
+        cPetStore.paths['/pets/{id}'].get.parameters = [{
+          in: 'query',
+          name: 'arg0',
+          type: 'integer'
+        }];
+
+        createServer(schemaValidator, [cPetStore], {}, function (app) {
+          request(app)
+            .get('/api/pets/1')
+            .query({
+              arg0: '2something'
+            })
+            .expect(400)
+            .end(helpers.expectContent(expectedMessage, done));
+        });
+      });
+
+      describe('should handle allowEmptyValue (Issue 282)', function () {
+        it('allowEmptyValue false', function (done) {
+          var cPetStore = _.cloneDeep(petStoreJson);
+          var expectedMessage = 'Request validation failed: Parameter (arg0) is not a valid integer: ';
+
+          cPetStore.paths['/pets/{id}'].get.parameters = [{
+            in: 'query',
+            name: 'arg0',
+            type: 'integer'
+          }];
+
+          createServer(schemaValidator, [cPetStore], {
+            swaggerRouterOptions: {
+              controllers: {
+                getPetById: function (req, res) {
+                  res.end('OK');
+                }
+              }
+            }
+          }, function (app) {
+            request(app)
+              .get('/api/pets/1')
+              .query({
+                arg0: ''
+              })
+              .expect(400)
+              .end(helpers.expectContent(expectedMessage, done));
+          });
+        });
+
+        it('allowEmptyValue true', function (done) {
+          var cPetStore = _.cloneDeep(petStoreJson);
+
+          cPetStore.paths['/pets/{id}'].get.parameters = [{
+            in: 'query',
+            name: 'arg0',
+            type: 'integer',
+            allowEmptyValue: true
+          }];
+
+          createServer(schemaValidator, [cPetStore], {
+            swaggerRouterOptions: {
+              controllers: {
+                getPetById: function (req, res) {
+                  res.end('OK');
+                }
+              }
+            }
+          }, function (app) {
+            try {
+              request(app)
+                .get('/api/pets/1')
+                .query({
+                  arg0: ''
+                })
+                .expect(200)
+                .end(helpers.expectContent('OK', done));
+            } catch (err) {
+              done();
+            }
+          });
+        });
+      });
+
+      it('should handle pattern validation for collectionFormat values (Issue 300)', function (done) {
+        var pattern = 'fake[|d|r]+';
+        var expectedMessage = 'Request validation failed: ' +
+          'Parameter (myArr) value at index 2 does not match required pattern: ' + pattern;
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].get.parameters.push({
+          in: 'query',
+          name: 'myArr',
+          description: 'Simple array value',
+          required: true,
+          type: 'array',
+          items: {
+            type: 'string',
+            pattern: pattern
+          },
+          collectionFormat: 'multi'
+        });
+
+        createServer(schemaValidator, [swaggerObject], {
           swaggerRouterOptions: {
             controllers: {
-              getPetById: function (req, res) {
+              getAllPets: function (req, res) {
+                res.end('NOT OK');
+              }
+            }
+          }
+      }, function(app) {
+          request(app)
+            .get('/api/pets')
+            .query({myArr: ['faker', 'faked', 'fakes']})
+            .expect(400)
+            .end(helpers.expectContent(expectedMessage, done));
+        });
+      });
+
+      it('should handle consumes/produces with charset (Issue 295)', function (done) {
+        var pet = {
+          id: 1,
+          name: 'Fake Pet'
+        };
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].post.consumes = ['application/xml', 'application/json; charset=utf-8'];
+        swaggerObject.paths['/pets'].post.produces = ['application/xml', 'application/json; charset=utf-8'];
+
+        createServer(schemaValidator, [swaggerObject], {
+          swaggerRouterOptions: {
+            controllers: {
+              createPet: function (req, res) {
+                res.setHeader('content-type', 'application/json; charset=utf-8');
+                res.end(JSON.stringify(req.swagger.params.pet.value));
+              }
+            }
+          }
+        }, function (app) {
+          request(app)
+            .post('/api/pets')
+            .set('content-type', 'application/json; charset=utf-8')
+            .send(pet)
+            .expect(200)
+            .end(helpers.expectContent(pet));
+
+          request(app)
+            .post('/api/pets')
+            .set('content-type', 'application/json')
+            .send(pet)
+            .expect(200)
+            .end(helpers.expectContent(pet, done));
+        });
+      });
+
+      it('should handle string values for arrays (PR #341)', function (done) {
+        var cPetStore = _.cloneDeep(petStoreJson);
+        var responseValue = [['abc', 'abbbc', 'abbbbbbbc']];
+
+        cPetStore.paths['/tags'] = {
+          get: {
+            summary: 'Get All Tags',
+            description: 'Retrieves a list of all available tags.',
+            operationId: 'getAllTags',
+            responses: {
+              '200': {
+                description: 'OK',
+                schema: {
+                  type: 'array',
+                  items: {
+                    type: 'array',
+                    items: {
+                      type: 'string',
+                      pattern: 'ab+c'
+                    }
+                  }
+                }
+              }
+            }
+          }
+        };
+
+        createServer(schemaValidator, [cPetStore], {
+          swaggerRouterOptions: {
+            controllers: {
+              getAllTags: function (req, res) {
+                res.end(JSON.stringify(responseValue));
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          try {
+            request(app)
+              .get('/api/tags')
+              .expect(200)
+              .end(helpers.expectContent(responseValue, done));
+          } catch (err) {
+            done();
+          }
+        });
+      });
+
+      it('should not throw an error for empty responses that validate void (new issue)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/categories/count'] = {
+          get: {
+            'x-swagger-router-controller': 'Pets',
+            operationId: 'getCategoryCount',
+            responses: {
+              '200': {
+                description: 'empty response'
+              }
+            }
+          }
+        };
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getCategoryCount': function (req, res) {
+                return res.end();
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/categories/count')
+            .expect(200)
+            .end(helpers.expectContent('', done));
+        });
+      });
+
+
+      it('should not throw an error for empty responses that validate void even with empty res.write (new issue)', function (done) {
+        var cPetStoreJson = _.cloneDeep(petStoreJson);
+
+        cPetStoreJson.paths['/pets/categories/count'] = {
+          get: {
+            'x-swagger-router-controller': 'Pets',
+            operationId: 'getCategoryCount',
+            responses: {
+              '200': {
+                description: 'empty response'
+              }
+            }
+          }
+        };
+
+        createServer(schemaValidator, [cPetStoreJson], {
+          swaggerRouterOptions: {
+            controllers: {
+              'Pets_getCategoryCount': function (req, res) {
+                res.write();
+                return res.end();
+              }
+            }
+          },
+          swaggerValidatorOptions: {
+            validateResponse: true
+          }
+        }, function (app) {
+          request(app)
+            .get('/api/pets/categories/count')
+            .expect(200)
+            .end(helpers.expectContent('', done));
+        });
+      });
+
+      it('should set failedValidation for Content-Type validation errors (PR 420)', function (done) {
+        var swaggerObject = _.cloneDeep(petStoreJson);
+
+        swaggerObject.paths['/pets'].post.consumes = ['application/xml'];
+
+        createServer(schemaValidator, [swaggerObject], {}, function (app) {
+          request(app)
+            .post('/api/pets')
+            .set('Accept', 'application/json')
+            .send({
+              id: 1,
+              name: 'Fake Pet'
+            })
+            .expect(400)
+            .end(helpers.expectContent({
+              failedValidation: true,
+              message: 'Invalid content type (application/json).  These are valid: application/xml'
+            }, done));
+        });
+      });
+    });
+  });
+} // End of tests to be run against both validators
+
+/**
+ * Runs tests that should only be run with a custom validator as they test
+ * usage of custom keywords not in the default validator
+ *
+ * @param {String} description  - description of the test suite
+ * @param {Object} [schemaValidator]  - optional custom validator to use
+ */
+function runCustomValidatorOnlyTests(description, schemaValidator) {
+  //
+  // Tests that should only be run with a custom validator.  This custom
+  // validator MUST have an additional `format` validator called `disallow-x`
+  // which returns an error if an `x` is included in the string.
+  //
+  describe('Swagger Validator Middleware v2.0 with ' + description, function () {
+    describe('with a custom format specified:', function () {
+      it('should fail with invalid input', function (done) {
+        var cPetStore = _.cloneDeep(petStoreJson);
+        cPetStore.definitions.Pet.properties.name.format = 'disallow-e';
+
+        createServer(schemaValidator, [cPetStore], {
+          swaggerRouterOptions: {
+            controllers: {
+              createPet: function (req, res) {
                 res.end('OK');
               }
             }
@@ -1440,9 +1730,39 @@ describe('Swagger Validator Middleware v2.0', function () {
         }, function (app) {
           try {
             request(app)
-              .get('/api/pets/1')
-              .query({
-                arg0: ''
+              .post('/api/pets')
+              .send({
+                id: 1,
+                name: 'e is not ok!'
+              })
+              .expect(400)
+              .end(helpers.expectContent('Request validation failed: Parameter (pet) ' +
+                'failed schema validation', done));
+          } catch (err) {
+            done();
+          }
+        });
+      });
+
+      it('should pass with valid input', function (done) {
+        var cPetStore = _.cloneDeep(petStoreJson);
+        cPetStore.definitions.Pet.properties.name.format = 'disallow-e';
+
+        createServer(schemaValidator, [cPetStore], {
+          swaggerRouterOptions: {
+            controllers: {
+              createPet: function (req, res) {
+                res.end('OK');
+              }
+            }
+          }
+        }, function (app) {
+          try {
+            request(app)
+              .post('/api/pets')
+              .send({
+                id: 1,
+                name: 'a is ok!'
               })
               .expect(200)
               .end(helpers.expectContent('OK', done));
@@ -1453,217 +1773,79 @@ describe('Swagger Validator Middleware v2.0', function () {
       });
     });
 
-    it('should handle pattern validation for collectionFormat values (Issue 300)', function (done) {
-      var pattern = 'fake[|d|r]+';
-      var expectedMessage = 'Request validation failed: ' +
-            'Parameter (myArr) value at index 2 does not match required pattern: ' + pattern;
-      var swaggerObject = _.cloneDeep(petStoreJson);
+    describe('with a custom keyword specified:', function () {
+      it('should fail invalid input', function (done) {
+        var cPetStore = _.cloneDeep(petStoreJson);
+        cPetStore.definitions.Pet.properties.name['x-is-even-length'] = true;
 
-      swaggerObject.paths['/pets'].get.parameters.push({
-          in: 'query',
-        name: 'myArr',
-        description: 'Simple array value',
-        required: true,
-        type: 'array',
-        items: {
-          type: 'string',
-          pattern: pattern
-        },
-        collectionFormat: 'multi'
-      });
-
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            getAllPets: function (req, res) {
-              res.end('NOT OK');
-            }
-          }
-        }
-      }, function(app) {
-        request(app)
-          .get('/api/pets')
-          .query({myArr: ['faker', 'faked', 'fakes']})
-          .expect(400)
-          .end(helpers.expectContent(expectedMessage, done));
-      });
-    });
-
-    it('should handle consumes/produces with charset (Issue 295)', function (done) {
-      var pet = {
-        id: 1,
-        name: 'Fake Pet'
-      };
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].post.consumes = ['application/xml', 'application/json; charset=utf-8'];
-      swaggerObject.paths['/pets'].post.produces = ['application/xml', 'application/json; charset=utf-8'];
-
-      helpers.createServer([swaggerObject], {
-        swaggerRouterOptions: {
-          controllers: {
-            createPet: function (req, res) {
-              res.setHeader('content-type', 'application/json; charset=utf-8');
-              res.end(JSON.stringify(req.swagger.params.pet.value));
-            }
-          }
-        }
-      }, function (app) {
-        request(app)
-          .post('/api/pets')
-          .set('content-type', 'application/json; charset=utf-8')
-          .send(pet)
-          .expect(200)
-          .end(helpers.expectContent(pet));
-
-        request(app)
-          .post('/api/pets')
-          .set('content-type', 'application/json')
-          .send(pet)
-          .expect(200)
-          .end(helpers.expectContent(pet, done));
-      });
-    });
-
-    it('should handle string values for arrays (PR #341)', function (done) {
-      var cPetStore = _.cloneDeep(petStoreJson);
-      var responseValue = [['abc', 'abbbc', 'abbbbbbbc']];
-
-      cPetStore.paths['/tags'] = {
-        get: {
-          summary: 'Get All Tags',
-          description: 'Retrieves a list of all available tags.',
-          operationId: 'getAllTags',
-          responses: {
-            '200': {
-              description: 'OK',
-              schema: {
-                type: 'array',
-                items: {
-                  type: 'array',
-                  items: {
-                    type: 'string',
-                    pattern: 'ab+c'
-                  }
-                }
+        createServer(schemaValidator, [cPetStore], {
+          swaggerRouterOptions: {
+            controllers: {
+              createPet: function (req, res) {
+                res.end('OK');
               }
             }
           }
-        }
-      };
-
-      helpers.createServer([cPetStore], {
-        swaggerRouterOptions: {
-          controllers: {
-            getAllTags: function (req, res) {
-              res.end(JSON.stringify(responseValue));
-            }
+        }, function (app) {
+          try {
+            request(app)
+              .post('/api/pets')
+              .send({
+                id: 1,
+                name: 'odd number of chars'
+              }).expect(400)
+              .end(helpers.expectContent('Request validation failed: Parameter (pet) ' +
+                'failed schema validation', done));
+          } catch (err) {
+            done();
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        try {
-          request(app)
-            .get('/api/tags')
-            .expect(200)
-            .end(helpers.expectContent(responseValue, done));
-        } catch (err) {
-          done();
-        }
+        });
       });
-    });
 
-    it('should not throw an error for empty responses that validate void (new issue)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
+      it('should pass valid input', function (done) {
+        var cPetStore = _.cloneDeep(petStoreJson);
+        cPetStore.definitions.Pet.properties.name['x-is-even-length'] = true;
 
-      cPetStoreJson.paths['/pets/categories/count'] = {
-        get: {
-          'x-swagger-router-controller': 'Pets',
-          operationId: 'getCategoryCount',
-          responses: {
-            '200': {
-              description: 'empty response'
+        createServer(schemaValidator, [cPetStore], {
+          swaggerRouterOptions: {
+            controllers: {
+              createPet: function (req, res) {
+                res.end('OK');
+              }
             }
           }
-        }
-      };
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getCategoryCount': function (req, res) {
-              return res.end();
-            }
+        }, function (app) {
+          try {
+            request(app)
+              .post('/api/pets')
+              .send({
+                id: 1,
+                name: 'even number of chars'
+              }).expect(200)
+              .end(helpers.expectContent('OK', done));
+          } catch (err) {
+            done();
           }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/categories/count')
-          .expect(200)
-          .end(helpers.expectContent('', done));
-      });
-    });
-
-
-    it('should not throw an error for empty responses that validate void even with empty res.write (new issue)', function (done) {
-      var cPetStoreJson = _.cloneDeep(petStoreJson);
-
-      cPetStoreJson.paths['/pets/categories/count'] = {
-        get: {
-          'x-swagger-router-controller': 'Pets',
-          operationId: 'getCategoryCount',
-          responses: {
-            '200': {
-              description: 'empty response'
-            }
-          }
-        }
-      };
-
-      helpers.createServer([cPetStoreJson], {
-        swaggerRouterOptions: {
-          controllers: {
-            'Pets_getCategoryCount': function (req, res) {
-              res.write();
-              return res.end();
-            }
-          }
-        },
-        swaggerValidatorOptions: {
-          validateResponse: true
-        }
-      }, function (app) {
-        request(app)
-          .get('/api/pets/categories/count')
-          .expect(200)
-          .end(helpers.expectContent('', done));
-      });
-    });
-
-    it('should set failedValidation for Content-Type validation errors (PR 420)', function (done) {
-      var swaggerObject = _.cloneDeep(petStoreJson);
-
-      swaggerObject.paths['/pets'].post.consumes = ['application/xml'];
-
-      helpers.createServer([swaggerObject], {}, function (app) {
-        request(app)
-          .post('/api/pets')
-          .set('Accept', 'application/json')
-          .send({
-            id: 1,
-            name: 'Fake Pet'
-          })
-          .expect(400)
-          .end(helpers.expectContent({
-            failedValidation: true,
-            message: 'Invalid content type (application/json).  These are valid: application/xml'
-          }, done));
+        });
       });
     });
   });
-});
+}
+
+/**
+ * Run all the base tests with both the default built-in validator, and again with
+ * a custom validators.
+ */
+runTestsWithSchemaValidator('Default validator'); // default built-in validator
+runTestsWithSchemaValidator('Custom AJV Validator', customValidatorHelpers.createAjv()); // Test with AJV validator
+runTestsWithSchemaValidator('Custom Z-Schema Validator', customValidatorHelpers.createZSchema()); // Test with Z-Schema validator
+
+/**
+ * Run the custom validator only tests
+ * These require that the custom validators have been initialised with:
+ * - a custom formt "disallow-e" which rejects strings with an "e"" in them
+ * - a custom keyword (vendor extension) "x-is-even-length" that rejects strings
+ *   that are not an even number of characters long.
+ */
+runCustomValidatorOnlyTests('Custom AJV Validator', customValidatorHelpers.createAjv()); // Test with AJV validator
+runCustomValidatorOnlyTests('Custom Z-Schema Validator', customValidatorHelpers.createZSchema()); // Test with Z-Schema validator

--- a/test/customValidatorHelpers.js
+++ b/test/customValidatorHelpers.js
@@ -1,0 +1,191 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Apigee Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+'use strict';
+
+var _ = require('lodash-compat');
+var Ajv = require('ajv');
+var ZSchema = require('z-schema');
+
+/**
+ * Options for intialising ajv.
+ * @see {@link https://github.com/epoberezkin/ajv#options}
+ */
+var AJV_OPTIONS = {
+    /* Return all errors, not just the first one */
+    allErrors: false,
+
+    /* Validate formats fully. Slower by more correct than 'fast' mode */
+    format: 'full',
+
+    /* Throw exceptions during schema compilation for unknown formats */
+    unknownFormats: true,
+
+    /* Don't remove additional properties, so that we can detect they exist and fail validation */
+    /* If removeAdditional = true, they are removed before they can be detected as additional */
+    removeAdditional: false,
+
+    /* Allow use of the default keyword. The default is cloned each time.*/
+    useDefaults: true,
+
+    /* Ensure all types are exactly as specified. E.g. this will not accept "1" as a number */
+    coerceTypes: false,
+
+    /* Additional formats allowed in swagger that are not in JSON schema. See http://swagger.io/specification/ */
+    formats: {
+        int32: function(val) {
+            return _.inRange(_.parseInt(val), -1 * Math.pow(2, 31), Math.pow(2, 31));
+        },
+        int64: function(val) {
+            console.log('Testing int64: ', val);
+            // JS can't actually safely handle integers in the full 64 bit range
+            // as they are actually IEE 754 doubles  See:
+            // https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Number/MAX_SAFE_INTEGER
+            return _.inRange(_.parseInt(val), -1 * Number.MAX_SAFE_INTEGER, Number.MAX_SAFE_INTEGER);
+        },
+        float: function(val) {
+            return _.isNaN(_.parseFloat(val));
+        },
+        double: function(val) {
+            return _.isNaN(_.parseFloat(val));
+        },
+        string: function(val) {
+            return _.isString(val);
+        },
+        'byte': /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/,
+        binary: function() {
+            return true;
+        },
+        'boolean': function(val) {
+            return _.isBoolean(val);
+        },
+        password: function(val) {
+            return _.isString(val);
+        }
+    }
+};
+
+/**
+ * Options for intialising z-schema.
+ * @see {@link https://github.com/zaggino/z-schema#options}
+ */
+var ZSCHEMA_OPTIONS = {
+    breakOnFirstError: false,
+    reportPathAsArray: true,
+    customValidator: function(report, schema, json) {
+        if (_.isBoolean(schema['x-is-even-length'])) {
+            var checkEven = schema['x-is-even-length'];
+            if (checkEven && (json.length % 2 !== 0)) {
+                report.addCustomError(
+                    'NON_EVEN_LENGTH_STRING',
+                    '"{0}" is not an even number of chars',
+                    [json], null, schema.description);
+            }
+        }
+    }
+};
+
+
+/**
+ * Creates and returns an appropriately wrapped version of the ajv validator.
+ * This mimics the z-schema API for validate() and getLastErrors()
+ *
+ * @return {Object} object that mimics Z-Schema's validator
+ */
+module.exports.createAjv = function createCustomAjvValidator() {
+    var ajv = new Ajv(AJV_OPTIONS);
+
+    /**
+     * To test the custom validation, we add a new test Format.
+     * This format returns an error if the string as an `e` in it
+     */
+    ajv.addFormat('disallow-e', function(val) {
+        return (val.indexOf('e') === -1);
+    });
+
+    /**
+     * Add a new keyword to verify we can do that too.
+     * This function checks a string is an even number of characters if set to true
+     */
+    ajv.addKeyword('x-is-even-length', {
+        errors: false,
+        async: false,
+        metaSchema: {
+            type: 'boolean'
+        },
+        compile: function isEven(schema) {
+            var checkEven = schema;
+
+            return function(data) {
+                return !checkEven || (data.length % 2 === 0);
+            };
+        }
+    });
+
+    /**
+     * Build an object with the required functions to match the Z-schema API
+     */
+    return {
+        /**
+         * Z-Sschema has the validate()) params in the opposite order to ajv,
+         * so flip them round. Note that this does not support async validation.
+         *
+         * @param {any} json    - the JSON object to validate
+         * @param {any} schema  - the schema or schema name to validate against
+         *
+         * @returns {boolean}   - true / false for success/fail.
+         */
+        validate: function zSchemaCompatValidate(json, schema) {
+            return ajv.validate(schema, json);
+        },
+
+        /**
+         * Z-schema has a function to get errors, while ajv has a property.
+         *
+         * @returns {array|null}  - an array of error objects, or null for no errors
+         */
+        getLastErrors: function zSchemaCompatGetLastErrors() {
+            return ajv.errors;
+        }
+    };
+};
+
+/**
+ * Creates and returns an appropriately initialised version of a custom Z-schema validator.
+ *
+ * @return {Object}   - z-schema validator instance
+ */
+module.exports.createZSchema = function createCustomZSchemaValidator() {
+    var validator = new ZSchema(ZSCHEMA_OPTIONS);
+
+    /**
+     * To test the custom validation, we add a new test Format.
+     * This format returns an error if the string as an `e` in it
+     */
+    ZSchema.registerFormat('disallow-e', function(val) {
+        return (val.indexOf('e') === -1);
+    });
+
+    return validator;
+};

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -125,9 +125,13 @@ var prepareText = module.exports.prepareText = function (text) {
 };
 
 module.exports.expectContent = function (content, done) {
-  return function (err, res) {
+  return function(err, res) {
     if (err) {
-      throw err;
+      if (_.isFunction(done)) {
+        return done(err);
+      } else {
+        throw err;
+      }
     }
 
     if (_.isArray(content) || _.isPlainObject(content)) {


### PR DESCRIPTION
This changeset provides an option to allow a custom JSON schema validator to be passed to the validation middleware.  See further discussion in #467.

In general this actually a small change. `validateAgainstSchema()` in `validators.js` already supported passing an external validator to it. So this change is mostly just adding another parameter to the options
that `swagger-validator` accepts, and then passing any validator down until it gets to `validateAgainstSchema()`.

There are other minor changes around error handling to be slightly more flexible in the error handling for validation errors, so that the custom validator doesn't have to be exactly identical in response to z-schema (the default validator).  If the response is not identical you will still get errors; you just won't get the slightly improved error messages that swagger-tools generates from the z-schema error messages in some corner cases.

This change also includes updated unit tests to check that:
- with no custom validator provided (the default), the existing tests continue to pass.
- the tests also pass when provided with suitably configured [z-schema](https://github.com/zaggino/z-schema) and [ajv](https://github.com/epoberezkin/ajv) custom validators.
- the z-schema and ajv custom validators can also validate custom `format`s and `vendor extension`s (also known as `custom keyword`s) that are not able to be verified using the default validator.

NOTE: this ONLY allows custom validation of `schema` objects in the  body of a request or response.

NOTE: `path` and `query` parameters, and the schema itself will still be validated by the inbuilt validators, irrespective of any validator passed in.

Finally, the `Middleware.md` docs have been updated with the new capability.

Test Plan:
- Run all unit tests and ensure they pass