### PR TITLE
Allow x-swagger-router-controller value to be a directory of operation files

### DIFF
--- a/docs/Middleware.md
+++ b/docs/Middleware.md
@@ -268,7 +268,7 @@ would have a value of `Pet_getById`.
 Since Swagger 2.0 has a new feature called **Vendor Extensions** which allows you to add additional properties
 throughout your Swagger documents as long as they start with `x-`.  Swagger Router uses a vendor extension named
 `x-swagger-router-controller` to help with the routing.  Basically, `x-swagger-router-controller` can be defined at the
-path level and/or the operation level and it tells the controller name to use.  To define the controller to use for an
+path level and/or the operation level and it tells the controller name to use. The value of `x-swagger-router-controller` can be a file or a folder. To define the controller to use for an
 operation, just define the `x-swagger-router-controller` property at the operation level.  What if you want to reuse the
 same controller for multiple/all operations in a path?  Just define the `x-swagger-router-controller` property at the
 path level.  Of course if you've defined `x-swagger-router-controller` at the path level and you want to use a different
@@ -277,7 +277,7 @@ controller for any operation below that path, you can override the path controll
 
 When it comes to finding the controller function to call, there are two options.  The default is to use the operation
 name for the operation, which corresponds to the HTTP verb being used.  If you want to override this default and use a
-different name, just define the `operationId` property on your operation.  Here is an example Swagger document snippet
+different name, just define the `operationId` property on your operation. In any case, if the value of `x-swagger-router-controller` is a directory, the files in that folder will be used as the individual operation functions and should be named accordingly. Here is an example Swagger document snippet
 where each operation tells you which controller and function will be used based on its definition:
 
 ```json

--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -92,12 +92,12 @@ var handlerCacheFromDir = function (dirOrDirs) {
           file = path.resolve(file);
           controller = require(file);
 
-          debug('    %s%s:', file, (_.isPlainObject(controller) ? '' : ' (not an object, skipped)'));
+          debug('    %s%s:', file, (_.isPlainObject(controller) || typeof controller === 'function' ? '' : ' (not an object or function, skipped)'));
 
+          var handlerId;
           if (_.isPlainObject(controller)) {
             _.each(controller, function (value, name) {
-              var handlerId = getFullQualifiedHandlerId(controllerName, name);
-
+              handlerId = getFullQualifiedHandlerId(controllerName, name);
               debug('      %s%s', handlerId, (_.isFunction(value) ? '' : ' (not a function, skipped)'));
 
               // TODO: Log this situation
@@ -120,6 +120,11 @@ var handlerCacheFromDir = function (dirOrDirs) {
                 }
               }
             });
+          } else if (typeof controller === 'function') {
+            handlerId = getFullQualifiedHandlerId(parent.split(path.sep).pop(), controllerName.split(path.sep).pop());
+            if (handlerCache[handlerId] === undefined) {
+              handlerCache[handlerId] = require(file);
+            }
           }
         }
       }

--- a/test/2.0/test-middleware-swagger-router.js
+++ b/test/2.0/test-middleware-swagger-router.js
@@ -188,6 +188,19 @@ describe('Swagger Router Middleware v2.0', function () {
     });
   });
 
+  it('should do routing when `x-swagger-router-controller` is a directory', function (done) {
+    helpers.createServer([petStoreJson], {
+      swaggerRouterOptions: {
+        controllers: path.join(__dirname, '..', 'controllerFolders')
+      }
+    }, function (app) {
+      request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent('controllerFolders/pets/getPetById.js swagger-router OK', done));
+    });
+  });
+
   it('should do routing when only operationId is given', function (done) {
     var cPetStoreJson = _.cloneDeep(petStoreJson);
     var controller = require('../controllers/Users');

--- a/test/controllerFolders/Pets/getPetById.js
+++ b/test/controllerFolders/Pets/getPetById.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = function getPetById(req, res) {
+  res.end('controllerFolders/pets/getPetById.js swagger-router OK');
+};


### PR DESCRIPTION
Given a swagger config:
```json
  "paths": {
    "/pets/{id}": {
      "get": {
        "operationId": "getPetsById",
      }
    }
  }
```
 and a router config:
```javascript
{
  swaggerRouterOptions: {
    controllers: './controllers'
  }
}
```
and the following directory structure:
```
controllers/
`-- Pets/
    `-- getPetById.js
```
This request will invoke `getPetById` as a function
```
GET /api/pets/123
200
```

Otherwise, all preexisting functionality is present.