### PR TITLE
Fixing issue with root level arrays

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -627,7 +627,7 @@ var validateSchemaConstraints = module.exports.validateSchemaConstraints = funct
     }
 
     if (type === 'array') {
-      _.each(val, function (val, index) {
+      _.each(JSON.parse(val), function (val, index) {
         try {
           validateSchemaConstraints(version, schema.items || {}, path.concat(index.toString()), val);
         } catch (err) {

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -627,7 +627,8 @@ var validateSchemaConstraints = module.exports.validateSchemaConstraints = funct
     }
 
     if (type === 'array') {
-      _.each(JSON.parse(val), function (val, index) {
+      
+      _.each(typeof val === 'string' ? JSON.parse(val) : val, function (val, index) {
         try {
           validateSchemaConstraints(version, schema.items || {}, path.concat(index.toString()), val);
         } catch (err) {

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -628,7 +628,7 @@ var validateSchemaConstraints = module.exports.validateSchemaConstraints = funct
 
     if (type === 'array') {
       
-      _.each(typeof val === 'string' ? JSON.parse(val) : val, function (val, index) {
+      _.each(_.isString(val) ? JSON.parse(val) : val, function (val, index) {
         try {
           validateSchemaConstraints(version, schema.items || {}, path.concat(index.toString()), val);
         } catch (err) {


### PR DESCRIPTION
When the `type` is `'array'` this code should iterate through the values of the array and validate each.
But the `val` variable contains the JSON string - so it will iterate on every character of that string. Starting with `'['` which will fail because it's not in the allowed values defined in the swagger file (of course).

The `JSON.parse` makes sure that the items will be iterated and not the chars of the string.