### PR TITLE
Add support for default controller

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ var initializeMiddleware = function initializeMiddleware (rlOrSO, resources, cal
           helpers.printValidationResults(spec.version, rlOrSO, resources, results, true);
         } else {
           console.error('Error initializing middleware');
+          console.error(err);
           console.error(err.stack);
         }
 

--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -51,8 +51,11 @@ var getHandlerName = function (req) {
         req.swagger.operation['x-swagger-router-controller'] :
         req.swagger.path['x-swagger-router-controller']) + '_' +
         (req.swagger.operation.operationId ? req.swagger.operation.operationId : req.method.toLowerCase());
-    } else {
+    } else if (req.swagger.operation.operationId) {
       handlerName = req.swagger.operation.operationId;
+    } else {
+      handlerName = req.swagger.apiPath.substring(1).replace(/\/\{.+\}/,'').replace('/','_') + '_' +
+        (req.swagger.operation.operationId ? req.swagger.operation.operationId : req.method.toLowerCase());
     }
 
     break;

--- a/test/2.0/test-middleware-swagger-router.js
+++ b/test/2.0/test-middleware-swagger-router.js
@@ -210,6 +210,28 @@ describe('Swagger Router Middleware v2.0', function () {
     });
   });
 
+  it('should do routing when nothing is given', function (done) {
+    var cPetStoreJson = _.cloneDeep(petStoreJson);
+    var controller = require('../controllers/Users');
+
+    // Use Users controller
+    delete cPetStoreJson.paths['/pets/{id}'].get['x-swagger-router-controller'];
+    delete cPetStoreJson.paths['/pets/{id}'].get.operationId;
+
+    helpers.createServer([cPetStoreJson], {
+      swaggerRouterOptions: {
+        controllers: {
+          'pets_get' : controller.getById
+        }
+      }
+    }, function (app) {
+      request(app)
+        .get('/api/pets/1')
+        .expect(200)
+        .end(helpers.expectContent(controller.response, done));
+    });
+  });
+
   it('should return an error when there is no controller and use of stubs is off', function (done) {
     var cOptions = _.cloneDeep(optionsWithControllersDir);
 


### PR DESCRIPTION
It'd be DRYer to default to using the controller will the path's name rather than doubly specifying the controller name.  e.g.

    /movie/{id}:
      x-swagger-router-controller: movie

This PR defaults to using the _movie_ controller for the _movie_ path.