### PR TITLE
bump qs dependency version to address CWE-20

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "multer": "^1.1.0",
     "parseurl": "^1.3.0",
     "path-to-regexp": "^1.2.0",
-    "qs": "^6.0.3",
+    "qs": "^6.0.4",
     "serve-static": "^1.10.0",
     "spark-md5": "^1.0.0",
     "string": "^3.3.0",


### PR DESCRIPTION
qs dependency is updated to fix the following weakness:
https://snyk.io/vuln/npm:qs:20170213

see current vulnerability report for swagger-tools
https://snyk.io/test/github/apigee-127/swagger-tools