### PR TITLE
Fix Issue 486: For a POST with body taking an array of strings, elements of the array can be improperly coerced into numeric values.

### DIFF
--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -113,7 +113,9 @@ var validateValue = function (req, schema, path, val, location, callback) {
   var isModel = mHelpers.isModelParameter(version, schema);
   var spec = cHelpers.getSpec(version);
 
-  val = mHelpers.convertValue(val, schema, mHelpers.getParameterType(schema), location);
+  // In swagger 2, a parameter in body will have a .schema, rather than be a schema: http://swagger.io/specification/#parameterObject
+  // etParameterType is already savvy to this, so we do what it does for the schema.
+  val = mHelpers.convertValue(val, _.isUndefined(schema.schema) ? schema : schema.schema, mHelpers.getParameterType(schema), location);
 
   try {
     validators.validateSchemaConstraints(version, schema, path, val);

--- a/middleware/swagger-validator.js
+++ b/middleware/swagger-validator.js
@@ -114,7 +114,7 @@ var validateValue = function (req, schema, path, val, location, callback) {
   var spec = cHelpers.getSpec(version);
 
   // In swagger 2, a parameter in body will have a .schema, rather than be a schema: http://swagger.io/specification/#parameterObject
-  // etParameterType is already savvy to this, so we do what it does for the schema.
+  // getParameterType() is already savvy to this, so we do what it does for the schema.
   val = mHelpers.convertValue(val, _.isUndefined(schema.schema) ? schema : schema.schema, mHelpers.getParameterType(schema), location);
 
   try {


### PR DESCRIPTION
In swagger 2, a parameter in body will have a .schema, rather than be a schema: http://swagger.io/specification/#parameterObject
getParameterType() is already savvy to this, so we do what it does for the schema.

Without this, you get a bogus schema, which eventually leads to converValue thinnking it's got an object type (the default), and attempting to JSON.stringify the nice string into an object.
