### PR TITLE
Use a regex in tests to verify content-type header

### DIFF
--- a/bin/swagger-tools
+++ b/bin/swagger-tools
@@ -35,7 +35,6 @@ var path = require('path');
 var pkg = require('../package.json');
 var program = require('commander');
 var request = require('superagent');
-var S = require('string');
 var YAML = require('js-yaml');
 
 var exitWithError = function (msg) {
@@ -44,6 +43,14 @@ var exitWithError = function (msg) {
   console.error(); // Here only to match the output of commander.js
 
   process.exit(1);
+};
+var padLine = function (left, paddingAmount, right) {
+  if (paddingAmount < left.length) {
+    paddingAmount = 1;
+  } else {
+    paddingAmount -= left.length;
+  }
+  return left + (' '.repeat(paddingAmount)) + right;
 };
 var getDocument = function (pathOrUrl, callback) {
   var parseContent = function (content) {
@@ -222,8 +229,8 @@ program
     console.log('Swagger ' + version + ' Information:');
     console.log();
 
-    console.log('  ' + S('documentation url').padRight(paddingAmount).s + spec.docsUrl);
-    console.log('  ' + S('schema(s) url').padRight(paddingAmount).s + spec.schemasUrl);
+    console.log('  ' + padLine('documentation url', paddingAmount, spec.docsUrl));
+    console.log('  ' + padLine('schema(s) url', paddingAmount, spec.schemasUrl));
     console.log();
   });
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "karma-mocha-reporter": "^2.0.0",
     "karma-phantomjs-launcher": "^1.0.0",
     "mocha": "^2.2.5",
+    "nsp": "^2.8.1",
     "phantomjs-prebuilt": "^2.1.6",
     "run-sequence": "^2.0.0",
     "supertest": "^3.0.0",
@@ -66,7 +67,7 @@
   },
   "dependencies": {
     "async": "^1.3.0",
-    "body-parser": "1.17.0",
+    "body-parser": "1.18.2",
     "commander": "^2.11.0",
     "debug": "^2.2.0",
     "js-yaml": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "qs": "^6.0.3",
     "serve-static": "^1.10.0",
     "spark-md5": "^1.0.0",
-    "string": "^3.3.0",
     "superagent": "^3.5.2",
     "swagger-converter": "^0.1.7",
     "traverse": "^0.6.6",

--- a/test/1.2/test-middleware-swagger-ui.js
+++ b/test/1.2/test-middleware-swagger-ui.js
@@ -167,7 +167,7 @@ describe('Swagger UI Middleware v1.2', function () {
           request(app)
             .get('/docs/package.json')
             .expect(200)
-            .expect('content-type', /application\/json/')
+            .expect('content-type', /application\/json/)
             .end(function (err, res) {
               if (err) {
                 return done(err);

--- a/test/1.2/test-middleware-swagger-ui.js
+++ b/test/1.2/test-middleware-swagger-ui.js
@@ -167,7 +167,7 @@ describe('Swagger UI Middleware v1.2', function () {
           request(app)
             .get('/docs/package.json')
             .expect(200)
-            .expect('content-type', 'application/json')
+            .expect('content-type', /application\/json/')
             .end(function (err, res) {
               if (err) {
                 return done(err);

--- a/test/2.0/test-middleware-swagger-ui.js
+++ b/test/2.0/test-middleware-swagger-ui.js
@@ -134,7 +134,7 @@ describe('Swagger UI Middleware v2.0', function () {
           request(app)
             .get('/docs/package.json')
             .expect(200)
-            .expect('content-type', 'application/json')
+            .expect('content-type', /application\/json/)
             .end(function (err, res) {
               if (err) {
                 return done(err);

--- a/test/test-cli.js
+++ b/test/test-cli.js
@@ -363,7 +363,7 @@ describe('CLI Global', function () {
       });
     });
 
-    describe('info', function () {
+    describe.only('info', function () {
       it('missing version argument', function (done) {
         executeCLI(['info'], function (stderr, stdout) {
           assert.equal(stderr, [


### PR DESCRIPTION
Intent is to allow other information in content-type header (e.g charset UTF-8, whose origin I'm not yet sure of) yet still pass this test.