### PR TITLE
Remove stringjs dependency due to vulnerability in string 3.3. It is …

### DIFF
--- a/bin/swagger-tools
+++ b/bin/swagger-tools
@@ -35,8 +35,12 @@ var path = require('path');
 var pkg = require('../package.json');
 var program = require('commander');
 var request = require('superagent');
-var S = require('string');
 var YAML = require('js-yaml');
+
+String.prototype.padRight = function (length) {
+  var pad = Array(256).join(' ');
+  return (this + pad).substring(0, length);
+};
 
 var exitWithError = function (msg) {
   console.error();
@@ -222,8 +226,8 @@ program
     console.log('Swagger ' + version + ' Information:');
     console.log();
 
-    console.log('  ' + S('documentation url').padRight(paddingAmount).s + spec.docsUrl);
-    console.log('  ' + S('schema(s) url').padRight(paddingAmount).s + spec.schemasUrl);
+    console.log('  ' + 'documentation url'.padRight(paddingAmount) + spec.docsUrl);
+    console.log('  ' + 'schema(s) url'.padRight(paddingAmount) + spec.schemasUrl);
     console.log();
   });
 

--- a/bin/swagger-tools
+++ b/bin/swagger-tools
@@ -37,9 +37,14 @@ var program = require('commander');
 var request = require('superagent');
 var YAML = require('js-yaml');
 
-String.prototype.padRight = function (length) {
-  var pad = Array(256).join(' ');
-  return (this + pad).substring(0, length);
+var padRight = function (s, len, ch) {
+  if (!ch) {
+    ch = ' ';
+  }
+  if (s.length >= len) {
+    return s;
+  }
+  return s + Array(len - s.length + 1).join(ch);
 };
 
 var exitWithError = function (msg) {
@@ -226,8 +231,8 @@ program
     console.log('Swagger ' + version + ' Information:');
     console.log();
 
-    console.log('  ' + 'documentation url'.padRight(paddingAmount) + spec.docsUrl);
-    console.log('  ' + 'schema(s) url'.padRight(paddingAmount) + spec.schemasUrl);
+    console.log('  ' + padRight('documentation url', paddingAmount) + spec.docsUrl);
+    console.log('  ' + padRight('schema(s) url', paddingAmount) + spec.schemasUrl);
     console.log();
   });
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "qs": "^6.0.3",
     "serve-static": "^1.10.0",
     "spark-md5": "^3.0.0",
-    "string": "^3.3.0",
     "superagent": "^3.5.2",
     "swagger-converter": "^0.1.7",
     "traverse": "^0.6.6",


### PR DESCRIPTION
Remove stringjs dependency due to vulnerability in string 3.3. It is used so little there is no need for the extra dependency in Swagger-tools.

Source: CERT
Name: https://nodesecurity.io/advisories/536
Url: https://nodesecurity.io/advisories/536
Source: CERT
Name: https://github.com/jprichardson/string.js/issues/212
Url: https://github.com/jprichardson/string.js/issues/212