### PR TITLE
Update superagent version due to sec vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "qs": "^6.0.3",
     "serve-static": "^1.10.0",
     "spark-md5": "^3.0.0",
-    "superagent": "^3.5.2",
+    "superagent": "^3.8.0",
     "swagger-converter": "^0.1.7",
     "traverse": "^0.6.6",
     "z-schema": "^3.15.4"


### PR DESCRIPTION
The used superagent version has a Large gzip Denial of Service vulnerability. See: https://nodesecurity.io/advisories/superagent_large-gzip-denial-of-service