### PR TITLE
Add type safety for `global.SwaggerConverter`

### DIFF
--- a/lib/specs.js
+++ b/lib/specs.js
@@ -35,7 +35,7 @@ var validators = require('./validators');
 var YAML = require('js-yaml');
 
 // Work around swagger-converter packaging issue (Browser builds only)
-if (_.isPlainObject(swaggerConverter)) {
+if (_.isPlainObject(swaggerConverter) && global.SwaggerConverter) {
   swaggerConverter = global.SwaggerConverter.convert;
 }
 


### PR DESCRIPTION
Hi there,

Keep running into this error in a private repo, so I thought I'd add a small check

```
TypeError: Cannot read property 'convert' of undefined
    at Object.<anonymous> (...src/node_modules/swagger-tools/lib/specs.js:39:46)
    at Module._compile (module.js:635:30)
```

I haven't yet looked closer as to why swagger-tools is involved in my code to be honest. Swagger is turned off using the `enabled: false` flag. swagger-tools is a sub dependency of a private library I don't have a lot of control over, so I thought it would be easier to submit a patch here.



