### PR TITLE
Exclude spec|test.js files from swagger-router

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -64,44 +64,46 @@ var getHandlerName = function (req) {
 
 var includeFile = function (str, options) {
 
-  const exclude = options.exclude
-  const include = options.include
+  var exclude = options.exclude;
+  var include = options.include;
 
   if(include) {
     if (_.isArray(include)) {
       if (include.length > 0) {
-        var match = _.some(include, function(regex) {
-          return regex.test(str)
-        })
-        if (!match) {
-          return false
+        if (!_.some(include, function(regex) {
+            return regex.test(str);
+          })) {
+          return false;
         }
       }
     }
     else {
-      if (!include.test(str)) return false
+      if (!include.test(str)) {
+        return false;
+      }
     }
   }
   if(exclude) {
     if (_.isArray(exclude)) {
       if (exclude.length > 0) {
-        var match = _.some(exclude, function (regex) {
-          return regex.test(str)
-        })
-        if (match) {
-          return false
+        if (_.some(exclude, function (regex) {
+            return regex.test(str);
+          })) {
+          return false;
         }
       }
     }
     else {
-      if (exclude.test(str)) return false
+      if (exclude.test(str)) {
+        return false;
+      }
     }
   }
   return true;
-}
+};
 
 var handlerCacheFromDir = exports.handlerCacheFromDir = function (options) {
-  const dirOrDirs = options.controllers
+  const dirOrDirs = options.controllers;
 
   var handlerCache = {};
   var jsFileRegex = /\.(coffee|js|ts)$/;

--- a/test/2.0/test-middleware-swagger-router.js
+++ b/test/2.0/test-middleware-swagger-router.js
@@ -177,6 +177,21 @@ describe('Swagger Router Middleware v2.0', function () {
     });
   });
 
+  it('should return an error when exclude is match and use of stubs is off', function (done) {
+    var cOptions = _.cloneDeep(optionsWithControllersDir);
+
+    cOptions.exclude = [/controllers/];
+
+    helpers.createServer([petStoreJson], {
+      swaggerRouterOptions: cOptions
+    }, function (app) {
+      request(app)
+        .get('/api/pets/1')
+        .expect(500)
+        .end(helpers.expectContent('Cannot resolve the configured swagger-router handler: Pets_getPetById', done));
+    });
+  });
+
   it('should return an error when there is no controller and ignoreMissingHandlers is true', function (done) {
     var cPetStoreJson = _.cloneDeep(petStoreJson);
     var cOptions = _.cloneDeep(optionsWithControllersDir);


### PR DESCRIPTION
I have some spec files along with the controller files in my controller directory. I should be able to ignore certain type of files.

Solves issue: #354 