### PR TITLE
fix incorrect status code on POST and DELETE (closes #592)

### DIFF
--- a/middleware/swagger-router.js
+++ b/middleware/swagger-router.js
@@ -229,7 +229,7 @@ var mockResponse = function (req, res, next, handlerName) {
       debug('send mock response: %s', response);
 
       // Explicitly set the response status to 200 if not present (Issue #269)
-      if (_.isUndefined(req.statusCode)) {
+      if (_.isUndefined(res.statusCode)) {
         res.statusCode = 200;
       }
 


### PR DESCRIPTION
A typo in swagger-route prevents to return the previously initialized status code by checking the wrong, variable resulting in an always `true` confition