### PR TITLE
BUG: swagger-metadata can't read value 1 of undefined

### DIFF
--- a/middleware/swagger-metadata.js
+++ b/middleware/swagger-metadata.js
@@ -398,8 +398,8 @@ exports = module.exports = function (rlOrSO, apiDeclarations) {
     var metadata;
 
     cacheEntry = apiCache[path] || _.find(apiCache, function (metadata) {
-      match = metadata.re.exec(path);
-      return _.isArray(match);
+      var isFound = metadata.re.exec(path);
+      return _.isArray(isFound);
     });
 
     debug('%s %s', req.method, req.url);
@@ -409,6 +409,7 @@ exports = module.exports = function (rlOrSO, apiDeclarations) {
     if (!cacheEntry) {
       return next();
     }
+    match = cacheEntry.re.exec(path);
 
     metadata = swaggerVersion === '1.2' ?
       {

--- a/test/2.0/test-middleware-swagger-metadata.js
+++ b/test/2.0/test-middleware-swagger-metadata.js
@@ -252,6 +252,17 @@ describe('Swagger Metadata Middleware v2.0', function () {
     });
   });
 
+  it('should not crash when passing wrong data in path',function(done) {
+    var cPetStoreJson = _.cloneDeep(petStoreJson);
+    
+     helpers.createServer([cPetStoreJson],{}, function (app) {
+      request(app)
+        .get('/api/pets/:id')
+        .expect(400)
+        .end(helpers.expectContent('Request validation failed: Parameter (id) is not a valid int64 integer: :id', done));
+    });
+  });
+
   describe('non-multipart form parameters', function () {
     it('should handle primitives', function (done) {
       var cPetStoreJson = _.cloneDeep(petStoreJson);


### PR DESCRIPTION
When the someone (maliciously or by mistake ) goes to a url such as pets/:id (literally see the test case ) the match value become undefined and [when getParameterValue treats it as a dictionary ](https://github.com/3mard/swagger-tools/blob/master/middleware/helpers.js#L110) it throws 500 error with a message can't read value 1 of undefined