### PR TITLE
fix insecure content error when loading swagger ui in chrome

### DIFF
--- a/middleware/swagger-ui/index.html
+++ b/middleware/swagger-ui/index.html
@@ -93,7 +93,7 @@ window.onload = function() {
   xhr.open('HEAD', document.location.href);
 
   xhr.onreadystatechange = function () {
-    var url = 'http://petstore.swagger.io/v2/swagger.json';
+    var url = 'https://petstore.swagger.io/v2/swagger.json';
 
     if (xhr.readyState === XMLHttpRequest.DONE) {
       url = xhr.getResponseHeader('Swagger-API-Docs-URL');


### PR DESCRIPTION
- UI is not loading due to mixed content errors. Addressing by updating http to https for the middeware file. Thank you!