### PR TITLE
Updated the version of z-schema to fix vulnerability

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 ## Release Notes
 
+### 0.10.5 (2022-03-01)
+
+* Updated the version of z-schema to fix vulnerability _(Issue #636)_
+
 ### 0.10.4 (2018-07-20)
 
 * Fix issue where an `object` with a `length` property was incorrectly traversed _(Issue #557)_

--- a/bower.json
+++ b/bower.json
@@ -38,6 +38,6 @@
     "swagger-converter": "~0.1.7",
     "traverse": "^0.6.7",
     "visionmedia-debug": "~3.1.0",
-    "z-schema": "~3.18.4"
+    "z-schema": "^5.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-tools",
-  "version": "0.10.3",
+  "version": "0.10.5",
   "description": "Various tools for using and integrating with Swagger.",
   "main": "index.js",
   "scripts": {
@@ -82,6 +82,6 @@
     "superagent": "^3.5.2",
     "swagger-converter": "^0.1.7",
     "traverse": "^0.6.6",
-    "z-schema": "^3.15.4"
+    "z-schema": "^5.0.2"
   }
 }


### PR DESCRIPTION
Vulnerability in validator package < 13.7.0

Updating z-schema package to 5.0.2 fixes this vulnerability as it depends on validator 13.7.0

I set package version to 0.10.5 as there is already a release with version 0.10.4
